### PR TITLE
use note[type="other"] where no other tag is assigned

### DIFF
--- a/sciencebeam_trainer_grobid_tools/structured_document/grobid_training_tei.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/grobid_training_tei.py
@@ -27,7 +27,11 @@ from sciencebeam_gym.structured_document import (
 TAG_ATTRIB_NAME = 'tag'
 
 
+DEFAULT_TAG_KEY = ''
+
+
 DEFAULT_TAG_TO_TEI_PATH_MAPPING = {
+    DEFAULT_TAG_KEY: 'note[type="other"]',
     'title': 'docTitle/titlePart',
     'abstract': 'div[type="abstract"]'
 }
@@ -236,6 +240,9 @@ def _lines_to_tei(tag_name, lines, tag_to_tei_path_mapping=None):
                     pending_space_tokens.append(token)
                     continue
                 required_path = []
+                default_path_str = tag_to_tei_path_mapping.get(DEFAULT_TAG_KEY)
+                if default_path_str:
+                    required_path = default_path_str.split('/')
 
             for pending_space_token in pending_space_tokens:
                 current_element, current_path = _get_element_at_path(

--- a/tests/structured_document/grobid_training_tei_test.py
+++ b/tests/structured_document/grobid_training_tei_test.py
@@ -12,7 +12,8 @@ from sciencebeam_trainer_grobid_tools.structured_document.grobid_training_tei im
     _lines_to_tei as _original_lines_to_tei,
     TeiLine,
     TeiText,
-    TAG_ATTRIB_NAME
+    TAG_ATTRIB_NAME,
+    DEFAULT_TAG_KEY
 )
 
 
@@ -286,7 +287,8 @@ class TestGrobidTrainingStructuredDocument(object):
         LOGGER.debug('original tei xml: %s', etree.tostring(original_tei_xml))
         doc = GrobidTrainingTeiStructuredDocument(
             original_tei_xml,
-            preserve_tags=True
+            preserve_tags=True,
+            tag_to_tei_path_mapping={}
         )
         LOGGER.debug('doc: %s', doc)
 
@@ -487,3 +489,14 @@ class TestLinesToTei(object):
                 token1=TOKEN_1, token2=TOKEN_2
             )
         )
+
+    def test_should_apply_default_tag(self):
+        tei_parent = _lines_to_tei(
+            'front',
+            [TeiLine([_tei_text(TOKEN_1, '')])],
+            tag_to_tei_path_mapping={
+                DEFAULT_TAG_KEY: 'other'
+            }
+        )
+        child_elements = list(tei_parent)
+        assert [c.tag for c in child_elements] == ['other']


### PR DESCRIPTION
When the training data is interpreted, text without a tag will assume the tag of the surrounding text.

To prevent that, we are wrapping the text without a tag with `note[type="other"]`, e.g.:

```xml
  <docTitle><titlePart>The title<lb/></titlePart></docTitle>
  <note type="other">Unrelated text<lb/></note>
```