### PR TITLE
fix preserve and override tag

### DIFF
--- a/sciencebeam_trainer_grobid_tools/structured_document/annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/annotator.py
@@ -23,7 +23,7 @@ def _iter_all_tokens(structured_document):
 
 def _map_token_tags(structured_document, tag_fn):
     for token in _iter_all_tokens(structured_document):
-        tag = structured_document.get_tag(token)
+        tag = structured_document.get_tag_or_preserved_tag(token)
         updated_tag = tag_fn(tag, token)
         if updated_tag != tag:
             structured_document.set_tag(token, updated_tag)

--- a/sciencebeam_trainer_grobid_tools/structured_document/grobid_training_tei.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/grobid_training_tei.py
@@ -236,33 +236,9 @@ def _lines_to_tei(tag_name, lines, tag_to_tei_path_mapping=None):
     for i, line in enumerate(lines):
         if i:
             current_element.append(E(TeiTagNames.LB))
-        # preserved_tags = [
-        #     token.attrib.get(PRESERVED_TAG_ATTRIB_NAME)
-        #     for token in line.tokens
-        # ]
-        # for line_preserved_tag in set(preserved_tags) - {None}:
-        #     preserved_line_tokens = [
-        #         token
-        #         for token, preserved_tag in zip(line.tokens, preserved_tags)
-        #         if preserved_tag == line_preserved_tag
-        #     ]
-        #     preserved_line_tokens_with_tags = [
-        #         token
-        #         for token in preserved_line_tokens
-        #         if token.attrib.get(TAG_ATTRIB_NAME)
-        #     ]
-        #     get_logger().debug('preserved_tags: %s', preserved_tags)
-        #     get_logger().debug('preserved_line_tokens_with_tags: %s', preserved_line_tokens_with_tags)
-        #     if preserved_line_tokens_with_tags:
-        #         preserved_tags = [
-        #             preserved_tag if preserved_tag != line_preserved_tag else None
-        #             for preserved_tag in preserved_tags
-        #         ]
-        #         get_logger().debug('preserved_tags (after clearing): %s (%s)', preserved_tags, line_preserved_tag)
         for token in line.tokens:
             tag = token.attrib.get(TAG_ATTRIB_NAME)
             if not tag:
-                # tag = preserved_tag
                 tag = token.attrib.get(PRESERVED_TAG_ATTRIB_NAME)
             if tag:
                 required_path = tag_to_tei_path_mapping.get(tag, tag).split('/')

--- a/tests/structured_document/grobid_training_tei_test.py
+++ b/tests/structured_document/grobid_training_tei_test.py
@@ -323,6 +323,31 @@ class TestGrobidTrainingStructuredDocument(object):
             )
         )
 
+    def test_should_not_return_preserved_tag_as_tag_and_update_preserved_tag(self):
+        original_tei_xml = _tei(front_items=[
+            E.note(TOKEN_1)
+        ])
+        LOGGER.debug('original tei xml: %s', etree.tostring(original_tei_xml))
+        doc = GrobidTrainingTeiStructuredDocument(
+            original_tei_xml,
+            preserve_tags=True,
+            tag_to_tei_path_mapping={}
+        )
+        LOGGER.debug('doc: %s', doc)
+        lines = _get_all_lines(doc)
+        token1 = list(doc.get_tokens_of_line(lines[0]))[0]
+        assert not doc.get_tag(token1)
+        doc.set_tag(token1, TAG_1)
+
+        root = doc.root
+        front = root.find('./text/front')
+        LOGGER.debug('xml: %s', etree.tostring(front))
+        assert etree.tostring(front) == (
+            '<front><{tag1}>{token1}</{tag1}></front>'.format(
+                token1=TOKEN_1, tag1=TAG_1
+            )
+        )
+
     def test_should_reverse_map_tags(self):
         tag_to_tei_path_mapping = {
             TAG_1: 'docTitle/titlePart'
@@ -339,7 +364,7 @@ class TestGrobidTrainingStructuredDocument(object):
         LOGGER.debug('doc: %s', doc)
 
         assert [
-            [doc.get_tag(t) for t in doc.get_all_tokens_of_line(line)]
+            [doc.get_tag_or_preserved_tag(t) for t in doc.get_all_tokens_of_line(line)]
             for line in _get_all_lines(doc)
         ] == [[TAG_1]]
 

--- a/tests/structured_document/grobid_training_tei_test.py
+++ b/tests/structured_document/grobid_training_tei_test.py
@@ -348,6 +348,32 @@ class TestGrobidTrainingStructuredDocument(object):
             )
         )
 
+    def test_should_only_preserve_tags_of_not_overlapping_lines(self):
+        original_tei_xml = _tei(front_items=[
+            E.note(TOKEN_1), E.note(TOKEN_2), E.lb(),
+            E.note(TOKEN_3)
+        ])
+        LOGGER.debug('original tei xml: %s', etree.tostring(original_tei_xml))
+        doc = GrobidTrainingTeiStructuredDocument(
+            original_tei_xml,
+            preserve_tags=True,
+            tag_to_tei_path_mapping={}
+        )
+        LOGGER.debug('doc: %s', doc)
+        lines = _get_all_lines(doc)
+        token1 = list(doc.get_tokens_of_line(lines[0]))[0]
+        assert not doc.get_tag(token1)
+        doc.set_tag(token1, TAG_1)
+
+        root = doc.root
+        front = root.find('./text/front')
+        LOGGER.debug('xml: %s', etree.tostring(front))
+        assert etree.tostring(front) == (
+            '<front><{tag1}>{token1}</{tag1}>{token2}<lb/><note>{token3}</note></front>'.format(
+                token1=TOKEN_1, token2=TOKEN_2, token3=TOKEN_3, tag1=TAG_1
+            )
+        )
+
     def test_should_reverse_map_tags(self):
         tag_to_tei_path_mapping = {
             TAG_1: 'docTitle/titlePart'


### PR DESCRIPTION
Preserved tags (from the model) prevented the overlapping text from being auto-annotated because it thought they were already tagged.

This is now hiding the preserved tags from `get_tag`. It is also clearing preserved tags on the same line to prevent partially preserved tags.