### PR TITLE
annotate lines before first front line as front

### DIFF
--- a/sciencebeam_trainer_grobid_tools/structured_document/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/segmentation_annotator.py
@@ -129,7 +129,7 @@ class SegmentationAnnotator(AbstractAnnotator):
                 tags = _get_line_token_tags_or_preserved_tags(structured_document, line)
                 if self.preserve_tags and SegmentationTagNames.PAGE in tags:
                     continue
-                if front_min_line_index <= line_index <= front_max_line_index:
+                if line_index <= front_max_line_index:
                     LOGGER.debug(
                         'tagging as front, within range (%d: %d -> %d)',
                         line_index, front_min_line_index, front_max_line_index

--- a/tests/structured_document/segmentation_annotator_test.py
+++ b/tests/structured_document/segmentation_annotator_test.py
@@ -205,6 +205,34 @@ class TestSegmentationAnnotator:
             [(SegmentationTagNames.FRONT, TOKEN_3)]
         ]
 
+    def test_should_annotate_untagged_lines_before_first_header(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [(OTHER_TAG, TOKEN_1)],
+            [(FrontTagNames.TITLE, TOKEN_2)],
+            [(FrontTagNames.TITLE, TOKEN_3)]
+        ])
+
+        SegmentationAnnotator(DEFAULT_CONFIG, preserve_tags=True).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [(SegmentationTagNames.FRONT, TOKEN_1)],
+            [(SegmentationTagNames.FRONT, TOKEN_2)],
+            [(SegmentationTagNames.FRONT, TOKEN_3)]
+        ]
+
+    def test_should_not_annotate_untagged_lines_after_last_header(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [(FrontTagNames.TITLE, TOKEN_1)],
+            [(FrontTagNames.TITLE, TOKEN_2)],
+            [(OTHER_TAG, TOKEN_3)],
+        ])
+
+        SegmentationAnnotator(DEFAULT_CONFIG, preserve_tags=True).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [(SegmentationTagNames.FRONT, TOKEN_1)],
+            [(SegmentationTagNames.FRONT, TOKEN_2)],
+            [(OTHER_TAG, TOKEN_3)]
+        ]
+
     def test_should_not_annotate_untagged_page_no_lines_between_first_and_last_header(self):
         doc = _simple_document_with_tagged_token_lines(lines=[
             [(FrontTagNames.TITLE, TOKEN_1)],


### PR DESCRIPTION
Annotate the lines before the first `front` line as `front` as well. e.g. the literal `Title`.