### PR TITLE
workaround xml parsing issues

### DIFF
--- a/sciencebeam_trainer_grobid_tools/auto_annotate_utils.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_utils.py
@@ -5,10 +5,7 @@ import os
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Set
 
-from lxml import etree
-
 import apache_beam as beam
-from apache_beam.io.filesystems import FileSystems
 from apache_beam.options.pipeline_options import PipelineOptions, SetupOptions
 
 from sciencebeam_utils.beam_utils.main import (
@@ -44,6 +41,7 @@ from sciencebeam_gym.preprocess.annotation.target_annotation import (
 
 from .utils.string import comma_separated_str_to_list
 from .utils.regex import regex_change_name
+from .utils.xml import parse_xml
 from .structured_document.annotator import annotate_structured_document
 from .structured_document.simple_matching_annotator import (
     SimpleMatchingAnnotator,
@@ -176,11 +174,6 @@ def process_annotation_pipeline_arguments(
     )
 
 
-def load_xml(file_url):
-    with FileSystems.open(file_url) as source_fp:
-        return etree.parse(source_fp)
-
-
 def get_xml_mapping_and_fields(xml_mapping_path, fields):
     xml_mapping = parse_xml_mapping(xml_mapping_path)
     if fields:
@@ -257,7 +250,7 @@ def get_default_annotators(
         annotators.append(LineAnnotator())
     if xml_path:
         target_annotations = xml_root_to_target_annotations(
-            load_xml(xml_path).getroot(),
+            parse_xml(xml_path).getroot(),
             xml_mapping
         )
         if annotator_config.matcher_name == MatcherNames.SIMPLE:

--- a/sciencebeam_trainer_grobid_tools/utils/xml.py
+++ b/sciencebeam_trainer_grobid_tools/utils/xml.py
@@ -1,0 +1,51 @@
+import logging
+from functools import partial
+from typing import Iterable
+
+from lxml import etree
+
+from apache_beam.io.filesystems import FileSystems
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class XMLSyntaxErrorWithErrorLine(ValueError):
+    def __init__(self, *args, error_line: str, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.error_line = error_line
+
+
+def _read_lines(source) -> Iterable[str]:
+    while True:
+        line = source.readline()
+        yield line
+
+
+def parse_xml_or_get_error_line(open_fn, filename: str = None, **kwargs):
+    try:
+        with open_fn() as source:
+            return etree.parse(source, **kwargs)
+    except etree.XMLSyntaxError as exception:
+        error_lineno = exception.lineno
+        with open_fn() as source:
+            try:
+                line_enumeration = enumerate(source, 1)
+            except TypeError:
+                line_enumeration = enumerate(_read_lines(source), 1)
+            for current_lineno, line in line_enumeration:
+                if current_lineno == error_lineno:
+                    raise XMLSyntaxErrorWithErrorLine(
+                        f'failed to parse xml file "%s", line=[{line}] due to {exception}' % (
+                            filename or exception.filename
+                        ),
+                        error_line=line
+                    ) from exception
+        raise exception
+
+
+def parse_xml(file_url):
+    return parse_xml_or_get_error_line(
+        partial(FileSystems.open, file_url),
+        filename=file_url
+    )

--- a/tests/auto_annotate_header_test.py
+++ b/tests/auto_annotate_header_test.py
@@ -81,3 +81,29 @@ class TestEndToEnd(object):
 
         tei_auto_root = test_helper.get_tei_auto_root()
         assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == TEXT_1
+
+    @log_on_exception
+    def test_should_skip_errors(
+            self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
+        tei_raw_other_file_path = test_helper.tei_raw_path.joinpath('document0.header.tei.xml')
+        tei_raw_other_file_path.write_bytes(etree.tostring(
+            get_header_tei_node([E.note(TEXT_1)])
+        ))
+        xml_other_file_path = test_helper.xml_path.joinpath('document0.xml')
+        xml_other_file_path.write_bytes(etree.tostring(
+            get_target_xml_node(title=TEXT_1)
+        ) + b'error')
+        test_helper.tei_raw_file_path.write_bytes(etree.tostring(
+            get_header_tei_node([E.note(TEXT_1)])
+        ))
+        test_helper.xml_file_path.write_bytes(etree.tostring(
+            get_target_xml_node(title=TEXT_1)
+        ))
+        main([
+            *test_helper.main_args,
+            '--matcher=simple',
+            '--skip-errors'
+        ], save_main_session=False)
+
+        tei_auto_root = test_helper.get_tei_auto_root()
+        assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == TEXT_1


### PR DESCRIPTION
Some XML files in a dataset may be invalid. This changes provides more information and allows one to skip errors.