### PR TITLE
don't extend title to whole line

### DIFF
--- a/config/annot-xml-front.conf
+++ b/config/annot-xml-front.conf
@@ -1,5 +1,7 @@
 [article]
 title = front/article-meta/title-group/article-title
+title.extend-to-line = false
+
 abstract = front/article-meta/abstract
 abstract.match-prefix-regex = (abstract|summary)\s*$
 

--- a/tests/auto_annotate_header_test.py
+++ b/tests/auto_annotate_header_test.py
@@ -83,6 +83,24 @@ class TestEndToEnd(object):
         assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == TEXT_1
 
     @log_on_exception
+    def test_should_extend_title_annotation_to_whole_line(
+            self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
+        title_text = 'Chocolate bars for mice'
+        test_helper.tei_raw_file_path.write_bytes(etree.tostring(
+            get_header_tei_node([E.note('Title: ' + title_text)])
+        ))
+        test_helper.xml_file_path.write_bytes(etree.tostring(
+            get_target_xml_node(title=title_text)
+        ))
+        main([
+            *test_helper.main_args,
+            '--matcher=simple'
+        ], save_main_session=False)
+
+        tei_auto_root = test_helper.get_tei_auto_root()
+        assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == title_text
+
+    @log_on_exception
     def test_should_auto_annotate_multiple_fields_using_simple_matcher(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
         title_text = 'Chocolate bars for mice'

--- a/tests/structured_document/simple_matching_annotator_test.py
+++ b/tests/structured_document/simple_matching_annotator_test.py
@@ -104,6 +104,14 @@ class TestGetExtendedLineTokenTags:
         token_tags = [None, None, TAG1, None, None]
         assert get_extended_line_token_tags(token_tags) == token_tags
 
+    def test_should_fill_begining_of_line_if_not_enabled_by_tag_config(self):
+        assert get_extended_line_token_tags(
+            [None, TAG1, TAG1],
+            extend_to_line_enabled_map={
+                TAG1: False
+            }
+        ) == [None, TAG1, TAG1]
+
 
 class TestSimpleMatchingAnnotator:
     def test_should_not_fail_on_empty_document(self):


### PR DESCRIPTION
we want to avoid that prefixes such as `Title: ` are included in the title.