### PR TITLE
use begin tag

### DIFF
--- a/config/xml-mapping.conf
+++ b/config/xml-mapping.conf
@@ -28,6 +28,7 @@ author.bonding = true
 author.match-multiple = true
 author.sub.surname = ./surname
 author.sub.givennames = ./given-names
+author.merge = true
 
 author_aff =
   front/article-meta/contrib-group/aff
@@ -46,6 +47,7 @@ author_aff.sub.extlink = ./ext-link
 author_aff.alternative-spellings =
   United States=USA
 # author_aff.match-prefix-regex = "(?=^|\n\s*)\d\s*$"
+author_aff.merge = false
 
 email =
   front/article-meta/contrib-group/aff/email

--- a/sciencebeam_trainer_grobid_tools/structured_document/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/segmentation_annotator.py
@@ -4,7 +4,11 @@ from collections import Counter
 from typing import Dict, List, Set
 
 from sciencebeam_utils.utils.string import parse_list
-from sciencebeam_gym.structured_document import AbstractStructuredDocument
+
+from sciencebeam_gym.structured_document import (
+    AbstractStructuredDocument,
+    strip_tag_prefix
+)
 from sciencebeam_gym.preprocess.annotation.annotator import (
     AbstractAnnotator
 )
@@ -90,6 +94,10 @@ def _get_line_token_tags(structured_document: AbstractStructuredDocument, line) 
     ]
 
 
+def _get_line_token_tag_values(*args, **kwargs) -> List[str]:
+    return list(map(strip_tag_prefix, _get_line_token_tags(*args, **kwargs)))
+
+
 def _get_line_token_tags_or_preserved_tags(
         structured_document: GrobidTrainingTeiStructuredDocument, line) -> List[str]:
     return [
@@ -121,7 +129,7 @@ class SegmentationAnnotator(AbstractAnnotator):
         untagged_indexed_lines = []
         min_max_by_tag = {}
         for line_index, line in enumerate(_iter_all_lines(structured_document)):
-            line_token_tags = _get_line_token_tags(structured_document, line)
+            line_token_tags = _get_line_token_tag_values(structured_document, line)
             line_tag_counts = Counter(line_token_tags)
             if not line_tag_counts:
                 continue

--- a/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
@@ -56,6 +56,7 @@ def split_and_join_with_space(text: str) -> str:
 
 
 DEFAULT_MERGE_ENABLED = True
+DEFAULT_EXTEND_TO_LINE_ENABLED = True
 
 
 class SimpleTagConfig:
@@ -64,7 +65,7 @@ class SimpleTagConfig:
             match_prefix_regex: str = None,
             alternative_spellings: Dict[str, List[str]] = None,
             merge_enabled: bool = DEFAULT_MERGE_ENABLED,
-            extend_to_line_enabled: bool = False):
+            extend_to_line_enabled: bool = DEFAULT_EXTEND_TO_LINE_ENABLED):
         self.match_prefix_regex = match_prefix_regex
         self.alternative_spellings = alternative_spellings
         self.merge_enabled = merge_enabled
@@ -230,8 +231,8 @@ def get_extended_line_token_tags(
         line_token_tags: List[str],
         extend_to_line_enabled_map: Dict[str, bool] = None,
         merge_enabled_map: Dict[str, bool] = None,
-        default_extend_to_line_enabled: bool = True,
-        default_merge_enabled: bool = True) -> List[str]:
+        default_extend_to_line_enabled: bool = DEFAULT_EXTEND_TO_LINE_ENABLED,
+        default_merge_enabled: bool = DEFAULT_MERGE_ENABLED) -> List[str]:
     if extend_to_line_enabled_map is None:
         extend_to_line_enabled_map = {}
     if merge_enabled_map is None:
@@ -559,7 +560,7 @@ def get_simple_tag_config(config_map: Dict[str, str], field: str) -> SimpleTagCo
         )),
         extend_to_line_enabled=strtobool(config_map.get(
             '%s.%s' % (field, SimpleTagConfigProps.EXTEND_TO_LINE),
-            'true'
+            str(DEFAULT_EXTEND_TO_LINE_ENABLED)
         ))
     )
 

--- a/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
@@ -561,11 +561,11 @@ def get_simple_tag_config(config_map: Dict[str, str], field: str) -> SimpleTagCo
         merge_enabled=strtobool(config_map.get(
             '%s.%s' % (field, SimpleTagConfigProps.MERGE),
             str(DEFAULT_MERGE_ENABLED)
-        )),
+        )) == 1,
         extend_to_line_enabled=strtobool(config_map.get(
             '%s.%s' % (field, SimpleTagConfigProps.EXTEND_TO_LINE),
             str(DEFAULT_EXTEND_TO_LINE_ENABLED)
-        ))
+        )) == 1
     )
 
 

--- a/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
@@ -55,20 +55,28 @@ def split_and_join_with_space(text: str) -> str:
     ])
 
 
+DEFAULT_MERGE_ENABLED = True
+
+
 class SimpleTagConfig:
     def __init__(
             self,
             match_prefix_regex: str = None,
             alternative_spellings: Dict[str, List[str]] = None,
+            merge_enabled: bool = DEFAULT_MERGE_ENABLED,
             extend_to_line_enabled: bool = False):
         self.match_prefix_regex = match_prefix_regex
         self.alternative_spellings = alternative_spellings
+        self.merge_enabled = merge_enabled
         self.extend_to_line_enabled = extend_to_line_enabled
 
     def __repr__(self):
-        return '%s(match_prefix_regex=%s, alternative_spellings=%s, extend_to_line_enabled=%s)' % (
+        return (
+            '%s(match_prefix_regex=%s, alternative_spellings=%s,'
+            + ' merge_enabled%s, extend_to_line_enabled=%s)'
+        ) % (
             type(self).__name__, self.match_prefix_regex, self.alternative_spellings,
-            self.extend_to_line_enabled
+            self.merge_enabled, self.extend_to_line_enabled
         )
 
 
@@ -221,12 +229,16 @@ def _to_inside_tag(tag: str) -> str:
 def get_extended_line_token_tags(
         line_token_tags: List[str],
         extend_to_line_enabled_map: Dict[str, bool] = None,
-        default_enabled: bool = True) -> List[str]:
+        merge_enabled_map: Dict[str, bool] = None,
+        default_extend_to_line_enabled: bool = True,
+        default_merge_enabled: bool = True) -> List[str]:
     if extend_to_line_enabled_map is None:
         extend_to_line_enabled_map = {}
+    if merge_enabled_map is None:
+        merge_enabled_map = {}
     LOGGER.debug(
-        'line_token_tags: %s (extend_to_line_enabled_map: %s)',
-        line_token_tags, extend_to_line_enabled_map
+        'line_token_tags: %s (extend_to_line_enabled_map: %s, merge_enabled_map: %s)',
+        line_token_tags, extend_to_line_enabled_map, merge_enabled_map
     )
     grouped_token_tags = [
         list(group)
@@ -239,15 +251,22 @@ def get_extended_line_token_tags(
         next_group = grouped_token_tags[index + 1] if index + 1 < len(grouped_token_tags) else None
         _, last_prev_tag_value = split_tag_prefix(_get_safe(prev_group, -1))
         first_next_prefix, first_next_tag_value = split_tag_prefix(_get_safe(next_group, 0))
-        if prev_group and not extend_to_line_enabled_map.get(last_prev_tag_value, default_enabled):
+        if (
+                prev_group and not extend_to_line_enabled_map.get(
+                    last_prev_tag_value, default_extend_to_line_enabled
+                )
+        ):
             result.extend(group)
         elif next_group and not extend_to_line_enabled_map.get(
-                first_next_tag_value, default_enabled):
+                first_next_tag_value, default_extend_to_line_enabled):
             result.extend(group)
         elif group[0]:
             result.extend(group)
         elif prev_group and next_group:
-            if last_prev_tag_value == first_next_tag_value:
+            if (
+                    last_prev_tag_value == first_next_tag_value
+                    and merge_enabled_map.get(last_prev_tag_value, default_merge_enabled)
+            ):
                 result.extend([_to_inside_tag(prev_group[-1])] * len(group))
                 if first_next_prefix == B_TAG_PREFIX:
                     next_group[0] = _to_inside_tag(next_group[0])
@@ -282,6 +301,14 @@ class SimpleMatchingAnnotator(AbstractAnnotator):
             raise ValueError('either config or kwargs should be specified')
         self.config = config
         LOGGER.debug('config: %s', config)
+        self.merge_enabled_map = {
+            tag: tag_confg.merge_enabled
+            for tag, tag_confg in self.config.tag_config_map.items()
+        }
+        self.extend_to_line_enabled_map = {
+            tag: tag_confg.extend_to_line_enabled
+            for tag, tag_confg in self.config.tag_config_map.items()
+        }
 
     def get_fuzzy_matching_index_range(
             self, haystack: str, needle, **kwargs):
@@ -431,16 +458,13 @@ class SimpleMatchingAnnotator(AbstractAnnotator):
                 yield index_range
 
     def extend_annotations_to_whole_line(self, structured_document: AbstractStructuredDocument):
-        extend_to_line_enabled_map = {
-            tag: tag_confg.extend_to_line_enabled
-            for tag, tag_confg in self.config.tag_config_map.items()
-        }
         for line in _iter_all_lines(structured_document):
             tokens = structured_document.get_tokens_of_line(line)
             line_token_tags = [structured_document.get_tag(token) for token in tokens]
             extended_line_token_tags = get_extended_line_token_tags(
                 line_token_tags,
-                extend_to_line_enabled_map=extend_to_line_enabled_map
+                extend_to_line_enabled_map=self.extend_to_line_enabled_map,
+                merge_enabled_map=self.merge_enabled_map
             )
             LOGGER.debug('line_token_tags: %s -> %s', line_token_tags, extended_line_token_tags)
             for token, token_tag in zip(tokens, extended_line_token_tags):
@@ -489,6 +513,7 @@ class SimpleMatchingAnnotator(AbstractAnnotator):
 class SimpleTagConfigProps:
     MATCH_PREFIX_REGEX = 'match-prefix-regex'
     ALTERNATIVE_SPELLINGS = 'alternative-spellings'
+    MERGE = 'merge'
     EXTEND_TO_LINE = 'extend-to-line'
 
 
@@ -528,6 +553,10 @@ def get_simple_tag_config(config_map: Dict[str, str], field: str) -> SimpleTagCo
         alternative_spellings=parse_alternative_spellings(config_map.get(
             '%s.%s' % (field, SimpleTagConfigProps.ALTERNATIVE_SPELLINGS)
         )),
+        merge_enabled=strtobool(config_map.get(
+            '%s.%s' % (field, SimpleTagConfigProps.MERGE),
+            str(DEFAULT_MERGE_ENABLED)
+        )),
         extend_to_line_enabled=strtobool(config_map.get(
             '%s.%s' % (field, SimpleTagConfigProps.EXTEND_TO_LINE),
             'true'
@@ -535,7 +564,8 @@ def get_simple_tag_config(config_map: Dict[str, str], field: str) -> SimpleTagCo
     )
 
 
-def get_simple_tag_config_map(xml_mapping: Dict[str, Dict[str, str]]):
+def get_simple_tag_config_map(
+        xml_mapping: Dict[str, Dict[str, str]]) -> Dict[str, SimpleTagConfig]:
     LOGGER.debug('xml_mapping: %s', xml_mapping)
     fields = {
         key

--- a/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
@@ -235,9 +235,10 @@ def get_extended_line_token_tags(
         next_group = grouped_token_tags[index + 1] if index + 1 < len(grouped_token_tags) else None
         _, last_prev_tag_value = split_tag_prefix(_get_safe(prev_group, -1))
         first_next_prefix, first_next_tag_value = split_tag_prefix(_get_safe(next_group, 0))
-        if prev_group and not extend_to_line_enabled_map.get(prev_group[0], default_enabled):
+        if prev_group and not extend_to_line_enabled_map.get(last_prev_tag_value, default_enabled):
             result.extend(group)
-        elif next_group and not extend_to_line_enabled_map.get(next_group[0], default_enabled):
+        elif next_group and not extend_to_line_enabled_map.get(
+                first_next_tag_value, default_enabled):
             result.extend(group)
         elif group[0]:
             result.extend(group)

--- a/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
@@ -276,7 +276,8 @@ def get_extended_line_token_tags(
         elif prev_group and len(prev_group) > len(group):
             result.extend([_to_inside_tag(prev_group[-1])] * len(group))
         elif next_group and len(next_group) > len(group):
-            result.extend(next_group[:1] * len(group))
+            result.extend([next_group[0]])
+            result.extend([_to_inside_tag(next_group[0])] * (len(group) - 1))
             if first_next_prefix == B_TAG_PREFIX:
                 next_group[0] = _to_inside_tag(next_group[0])
         else:

--- a/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
@@ -467,7 +467,10 @@ class SimpleMatchingAnnotator(AbstractAnnotator):
                 extend_to_line_enabled_map=self.extend_to_line_enabled_map,
                 merge_enabled_map=self.merge_enabled_map
             )
-            LOGGER.debug('line_token_tags: %s -> %s', line_token_tags, extended_line_token_tags)
+            LOGGER.debug(
+                'line_token_tags, transformed: %s -> %s (tokens: %s)',
+                line_token_tags, extended_line_token_tags, tokens
+            )
             for token, token_tag in zip(tokens, extended_line_token_tags):
                 if not token_tag:
                     continue

--- a/tests/structured_document/grobid_training_tei_test.py
+++ b/tests/structured_document/grobid_training_tei_test.py
@@ -350,6 +350,25 @@ class TestGrobidTrainingStructuredDocument(object):
             )
         )
 
+    def test_should_preserve_separation_between_existing_tag(self):
+        original_tei_xml = _tei(front_items=[
+            E.byline(E.affiliation(TOKEN_1)),
+            E.byline(E.affiliation(TOKEN_2))
+        ])
+        LOGGER.debug('original tei xml: %s', _to_xml(original_tei_xml))
+        doc = GrobidTrainingTeiStructuredDocument(
+            original_tei_xml,
+            preserve_tags=True,
+            tag_to_tei_path_mapping={}
+        )
+        LOGGER.debug('doc: %s', doc)
+
+        root = doc.root
+        front = root.find('./text/front')
+        affiliations = front.xpath('./byline/affiliation')
+        LOGGER.debug('xml: %s', _to_xml(front))
+        assert [aff.text for aff in affiliations] == [TOKEN_1, TOKEN_2]
+
     def test_should_preserve_existing_tag_with_attrib(self):
         original_tei_xml = _tei(front_items=[
             E.div(TOKEN_1, {'tag': TAG_1}),
@@ -439,7 +458,7 @@ class TestGrobidTrainingStructuredDocument(object):
         LOGGER.debug('doc: %s', doc)
 
         assert [
-            [doc.get_tag_or_preserved_tag(t) for t in doc.get_all_tokens_of_line(line)]
+            [doc.get_tag_or_preserved_tag_value(t) for t in doc.get_all_tokens_of_line(line)]
             for line in _get_all_lines(doc)
         ] == [[TAG_1]]
 

--- a/tests/structured_document/simple_matching_annotator_test.py
+++ b/tests/structured_document/simple_matching_annotator_test.py
@@ -612,9 +612,9 @@ class TestGetSimpleTagConfigMap:
             }
         })
         assert set(tag_config_map.keys()) == {'tag1', 'tag2', 'tag3'}
-        assert tag_config_map['tag1'].merge_enabled == False
-        assert tag_config_map['tag2'].merge_enabled == True
-        assert tag_config_map['tag3'].merge_enabled == DEFAULT_MERGE_ENABLED
+        assert tag_config_map['tag1'].merge_enabled is False
+        assert tag_config_map['tag2'].merge_enabled is True
+        assert tag_config_map['tag3'].merge_enabled is DEFAULT_MERGE_ENABLED
 
     def test_should_parse_extend_to_line_flag(self):
         tag_config_map = get_simple_tag_config_map({
@@ -627,9 +627,9 @@ class TestGetSimpleTagConfigMap:
             }
         })
         assert set(tag_config_map.keys()) == {'tag1', 'tag2', 'tag3'}
-        assert tag_config_map['tag1'].extend_to_line_enabled == False
-        assert tag_config_map['tag2'].extend_to_line_enabled == True
-        assert tag_config_map['tag3'].extend_to_line_enabled == DEFAULT_EXTEND_TO_LINE_ENABLED
+        assert tag_config_map['tag1'].extend_to_line_enabled is False
+        assert tag_config_map['tag2'].extend_to_line_enabled is True
+        assert tag_config_map['tag3'].extend_to_line_enabled is DEFAULT_EXTEND_TO_LINE_ENABLED
 
     def test_should_parse_match_prefix_regex(self):
         tag_config_map = get_simple_tag_config_map({

--- a/tests/structured_document/simple_matching_annotator_test.py
+++ b/tests/structured_document/simple_matching_annotator_test.py
@@ -11,7 +11,8 @@ from sciencebeam_gym.structured_document import (
     SimpleToken,
     B_TAG_PREFIX,
     I_TAG_PREFIX,
-    add_tag_prefix
+    add_tag_prefix,
+    strip_tag_prefix
 )
 
 from sciencebeam_gym.preprocess.annotation.target_annotation import (
@@ -43,6 +44,10 @@ I_TAG2 = add_tag_prefix(TAG2, prefix=I_TAG_PREFIX)
 
 def _get_tags_of_tokens(tokens):
     return [t.get_tag() for t in tokens]
+
+
+def _get_tag_values_of_tokens(tokens):
+    return [strip_tag_prefix(tag) for tag in _get_tags_of_tokens(tokens)]
 
 
 def _tokens_for_text(text):
@@ -202,7 +207,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([matching_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_match_case_insensitive(self):
         matching_tokens = _tokens_for_text('This Is Matching')
@@ -211,7 +216,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = SimpleStructuredDocument(lines=[SimpleLine(matching_tokens)])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_match_single_quotes_with_double_quotes(self):
         matching_tokens = _tokens_for_text('"this is matching"')
@@ -220,7 +225,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = SimpleStructuredDocument(lines=[SimpleLine(matching_tokens)])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_match_apos_with_double_quotes(self):
         matching_tokens = _tokens_for_text('"this is matching"')
@@ -229,7 +234,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = SimpleStructuredDocument(lines=[SimpleLine(matching_tokens)])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_prefer_word_boundaries(self):
         pre_tokens = _tokens_for_text('this')
@@ -242,9 +247,9 @@ class TestSimpleMatchingAnnotator:
             pre_tokens + matching_tokens + post_tokens
         ])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
-        assert _get_tags_of_tokens(pre_tokens) == [None] * len(pre_tokens)
-        assert _get_tags_of_tokens(post_tokens) == [None] * len(post_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(pre_tokens) == [None] * len(pre_tokens)
+        assert _get_tag_values_of_tokens(post_tokens) == [None] * len(post_tokens)
 
     def test_should_annotate_fuzzily_matching(self):
         matching_tokens = _tokens_for_text('this is matching')
@@ -253,7 +258,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([matching_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_annotate_using_alternative_spellings(self):
         matching_tokens = _tokens_for_text('this is matching')
@@ -269,7 +274,7 @@ class TestSimpleMatchingAnnotator:
                 })
             }
         ).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_annotate_ignoring_space_after_dot_short_sequence(self):
         matching_tokens = [
@@ -280,7 +285,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([matching_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_annotate_ignoring_comma_after_short_sequence(self):
         matching_tokens = [
@@ -291,7 +296,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([matching_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_annotate_including_final_dot(self):
         matching_tokens = _tokens_for_text('this is matching.')
@@ -300,7 +305,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([matching_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_annotate_ignoring_dots_after_capitals_in_target_annotation(self):
         matching_tokens = _tokens_for_text('PO Box 12345')
@@ -309,7 +314,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([matching_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     @pytest.mark.skip(reason="this is currently failing, needs more investigation")
     def test_should_annotate_ignoring_dots_after_capitals_in_document(self):
@@ -341,8 +346,8 @@ class TestSimpleMatchingAnnotator:
             target_annotations,
             tag_config_map={TAG1: SimpleTagConfig(match_prefix_regex=r'(?=^|\n)\d\s*$')}
         ).annotate(doc)
-        assert _get_tags_of_tokens(number_tokens) == [TAG1] * len(number_tokens)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(number_tokens) == [TAG1] * len(number_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_not_annotate_author_aff_preceding_number_if_it_is_following_text(self):
         number_tokens = _tokens_for_text('Smith 1')
@@ -355,8 +360,8 @@ class TestSimpleMatchingAnnotator:
             target_annotations,
             tag_config_map={TAG1: SimpleTagConfig(match_prefix_regex=r'(?=^|\n)\d\s*$')}
         ).annotate(doc)
-        assert _get_tags_of_tokens(number_tokens) == [None] * len(number_tokens)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(number_tokens) == [None] * len(number_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     @log_on_exception
     def test_should_not_annotate_author_aff_label_between_author_names(self):
@@ -371,8 +376,28 @@ class TestSimpleMatchingAnnotator:
             target_annotations,
             tag_config_map={}
         ).annotate(doc)
-        assert _get_tags_of_tokens(author_tokens) == [TAG1] * len(author_tokens)
-        assert _get_tags_of_tokens(aff_tokens) == [TAG2] * len(aff_tokens)
+        assert _get_tag_values_of_tokens(author_tokens) == [TAG1] * len(author_tokens)
+        assert _get_tag_values_of_tokens(aff_tokens) == [TAG2] * len(aff_tokens)
+
+    @log_on_exception
+    def test_should_annotate_separate_author_aff_with_begin_prefix(self):
+        aff1_tokens = _tokens_for_text('University of Science')
+        aff2_tokens = _tokens_for_text('University of Madness')
+        target_annotations = [
+            TargetAnnotation(['1', 'University of Science'], TAG1),
+            TargetAnnotation(['2', 'University of Madness'], TAG1)
+        ]
+        doc = _document_for_tokens([aff1_tokens, aff2_tokens])
+        SimpleMatchingAnnotator(
+            target_annotations,
+            tag_config_map={}
+        ).annotate(doc)
+        assert (
+            _get_tags_of_tokens(aff1_tokens) == [B_TAG1] + [I_TAG1] * (len(aff1_tokens) - 1)
+        )
+        assert (
+            _get_tags_of_tokens(aff2_tokens) == [B_TAG1] + [I_TAG1] * (len(aff2_tokens) - 1)
+        )
 
     def test_should_annotate_abstract_section_heading(self):
         matching_tokens = _tokens_for_text('Abstract\nthis is matching.')
@@ -384,7 +409,7 @@ class TestSimpleMatchingAnnotator:
             target_annotations,
             tag_config_map={TAG1: SimpleTagConfig(match_prefix_regex=r'(abstract|summary)\s*$')}
         ).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_not_annotate_fuzzily_matching_with_many_differences(self):
         matching_tokens = _tokens_for_text('this is matching')
@@ -415,7 +440,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens(matching_tokens_per_line)
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
 
     def test_should_annotate_over_multiple_lines_with_tag_transition(self):
         tag1_tokens_by_line = [
@@ -439,8 +464,8 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens(tokens_by_line)
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(tag1_tokens) == [TAG1] * len(tag1_tokens)
-        assert _get_tags_of_tokens(tag2_tokens) == [TAG2] * len(tag2_tokens)
+        assert _get_tag_values_of_tokens(tag1_tokens) == [TAG1] * len(tag1_tokens)
+        assert _get_tag_values_of_tokens(tag2_tokens) == [TAG2] * len(tag2_tokens)
 
     def test_should_annotate_multiple_value_annotation(self):
         pre_tokens = _tokens_for_text('this is')
@@ -452,9 +477,9 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([doc_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
-        assert _get_tags_of_tokens(pre_tokens) == [None] * len(pre_tokens)
-        assert _get_tags_of_tokens(post_tokens) == [None] * len(post_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(pre_tokens) == [None] * len(pre_tokens)
+        assert _get_tag_values_of_tokens(post_tokens) == [None] * len(post_tokens)
 
     def test_should_annotate_multiple_value_annotation_in_reverse_order(self):
         pre_tokens = _tokens_for_text('this is')
@@ -466,9 +491,9 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([doc_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
-        assert _get_tags_of_tokens(pre_tokens) == [None] * len(pre_tokens)
-        assert _get_tags_of_tokens(post_tokens) == [None] * len(post_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(pre_tokens) == [None] * len(pre_tokens)
+        assert _get_tag_values_of_tokens(post_tokens) == [None] * len(post_tokens)
 
     def test_should_annotate_multiple_value_annotation_too_far_away(self):
         pre_tokens = _tokens_for_text('this is')
@@ -480,9 +505,9 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([doc_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
-        assert _get_tags_of_tokens(pre_tokens) == [None] * len(pre_tokens)
-        assert _get_tags_of_tokens(post_tokens) == [None] * len(post_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(pre_tokens) == [None] * len(pre_tokens)
+        assert _get_tag_values_of_tokens(post_tokens) == [None] * len(post_tokens)
 
     @log_on_exception
     def test_should_annotate_and_merge_multiple_authors_annotation(self):
@@ -495,9 +520,9 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([pre_tokens, matching_tokens, post_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
-        assert _get_tags_of_tokens(pre_tokens) == [None] * len(pre_tokens)
-        assert _get_tags_of_tokens(post_tokens) == [None] * len(post_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(pre_tokens) == [None] * len(pre_tokens)
+        assert _get_tag_values_of_tokens(post_tokens) == [None] * len(post_tokens)
 
     @log_on_exception
     def test_should_annotate_but_not_merge_multiple_authors_annotation_too_far_apart(self):
@@ -514,11 +539,11 @@ class TestSimpleMatchingAnnotator:
             pre_tokens, matching_tokens_1, mid_tokens, matching_tokens_2, post_tokens
         ])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens_1) == [TAG1] * len(matching_tokens_1)
-        assert _get_tags_of_tokens(matching_tokens_2) == [TAG1] * len(matching_tokens_2)
-        assert _get_tags_of_tokens(mid_tokens) == [None] * len(mid_tokens)
-        assert _get_tags_of_tokens(pre_tokens) == [None] * len(pre_tokens)
-        assert _get_tags_of_tokens(post_tokens) == [None] * len(post_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens_1) == [TAG1] * len(matching_tokens_1)
+        assert _get_tag_values_of_tokens(matching_tokens_2) == [TAG1] * len(matching_tokens_2)
+        assert _get_tag_values_of_tokens(mid_tokens) == [None] * len(mid_tokens)
+        assert _get_tag_values_of_tokens(pre_tokens) == [None] * len(pre_tokens)
+        assert _get_tag_values_of_tokens(post_tokens) == [None] * len(post_tokens)
 
     @log_on_exception
     def test_should_annotate_whole_line(self):
@@ -531,9 +556,9 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([matching_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
-        assert _get_tags_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
-        assert _get_tags_of_tokens(pre_tokens) == [None] * len(pre_tokens)
-        assert _get_tags_of_tokens(post_tokens) == [None] * len(post_tokens)
+        assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
+        assert _get_tag_values_of_tokens(pre_tokens) == [None] * len(pre_tokens)
+        assert _get_tag_values_of_tokens(post_tokens) == [None] * len(post_tokens)
 
 
 class TestGetSimpleTagConfigMap:

--- a/tests/structured_document/simple_matching_annotator_test.py
+++ b/tests/structured_document/simple_matching_annotator_test.py
@@ -134,6 +134,14 @@ class TestGetExtendedLineTokenTags:
             }
         ) == [None, TAG1, TAG1]
 
+    def test_should_fill_begining_of_line_if_not_enabled_by_tag_config_with_begin_prefix(self):
+        assert get_extended_line_token_tags(
+            [None, B_TAG1, I_TAG1],
+            extend_to_line_enabled_map={
+                TAG1: False
+            }
+        ) == [None, B_TAG1, I_TAG1]
+
 
 class TestSimpleMatchingAnnotator:
     def test_should_not_fail_on_empty_document(self):

--- a/tests/structured_document/simple_matching_annotator_test.py
+++ b/tests/structured_document/simple_matching_annotator_test.py
@@ -8,7 +8,10 @@ from sciencebeam_utils.utils.collection import flatten
 from sciencebeam_gym.structured_document import (
     SimpleStructuredDocument,
     SimpleLine,
-    SimpleToken
+    SimpleToken,
+    B_TAG_PREFIX,
+    I_TAG_PREFIX,
+    add_tag_prefix
 )
 
 from sciencebeam_gym.preprocess.annotation.target_annotation import (
@@ -30,6 +33,12 @@ LOGGER = logging.getLogger(__name__)
 
 TAG1 = 'tag1'
 TAG2 = 'tag2'
+
+B_TAG1 = add_tag_prefix(TAG1, prefix=B_TAG_PREFIX)
+I_TAG1 = add_tag_prefix(TAG1, prefix=I_TAG_PREFIX)
+
+B_TAG2 = add_tag_prefix(TAG2, prefix=B_TAG_PREFIX)
+I_TAG2 = add_tag_prefix(TAG2, prefix=I_TAG_PREFIX)
 
 
 def _get_tags_of_tokens(tokens):
@@ -87,13 +96,26 @@ class TestGetExtendedLineTokenTags:
     def test_should_fill_begining_of_line(self):
         assert get_extended_line_token_tags([None, TAG1, TAG1]) == [TAG1] * 3
 
+    def test_should_fill_begining_of_line_with_begin_prefix(self):
+        assert get_extended_line_token_tags(
+            [None, B_TAG1, I_TAG1]
+        ) == [B_TAG1, I_TAG1, I_TAG1]
+
     def test_should_fill_end_of_line(self):
         assert get_extended_line_token_tags([TAG1, TAG1, None]) == [TAG1] * 3
+
+    def test_should_fill_end_of_line_with_begin_prefix(self):
+        assert get_extended_line_token_tags([B_TAG1, I_TAG1, None]) == [B_TAG1, I_TAG1, I_TAG1]
 
     def test_should_fill_gaps_if_same_tag(self):
         assert get_extended_line_token_tags(
             [TAG1, None, TAG1]
         ) == [TAG1, TAG1, TAG1]
+
+    def test_should_fill_gaps_if_same_tag_with_begin_prefix(self):
+        assert get_extended_line_token_tags(
+            [B_TAG1, None, B_TAG1]
+        ) == [B_TAG1, I_TAG1, I_TAG1]
 
     def test_should_not_fill_gaps_if_not_same_tag(self):
         assert get_extended_line_token_tags(

--- a/tests/structured_document/simple_matching_annotator_test.py
+++ b/tests/structured_document/simple_matching_annotator_test.py
@@ -111,7 +111,15 @@ class TestGetExtendedLineTokenTags:
         assert get_extended_line_token_tags(
             [None, B_TAG1, I_TAG1],
             extend_to_line_enabled_map={TAG1: True},
+            merge_enabled_map={TAG1: False}
         ) == [B_TAG1, I_TAG1, I_TAG1]
+
+    def test_should_fill_multi_token_begining_of_line_with_begin_prefix(self):
+        assert get_extended_line_token_tags(
+            [None, None, B_TAG1, I_TAG1, I_TAG1, I_TAG1],
+            extend_to_line_enabled_map={TAG1: True},
+            merge_enabled_map={TAG1: False}
+        ) == [B_TAG1, I_TAG1, I_TAG1, I_TAG1, I_TAG1, I_TAG1]
 
     def test_should_fill_end_of_line(self):
         assert get_extended_line_token_tags(


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5491

This keeps track of the beginning of tags by internally using tag prefixes (`b-` and `i-`).
Some tags, maybe most tags, do not expect to be separated, e.g. `docAuthor` usually refers to the whole line. Whereas `affiliation` is separated.

That is why there is a new tag config `merge`.