### PR TITLE
reference auto annotation

### DIFF
--- a/config/xml-mapping.conf
+++ b/config/xml-mapping.conf
@@ -60,6 +60,8 @@ reference = back/ref-list/ref
 reference.children = .//*
 reference.children.concat = [[{"xpath": ".//fpage"}, {"value": "-"}, {"xpath": ".//lpage"}]]
 reference.bonding = true
+reference.merge = false
+reference.block = references
 
 # page
 

--- a/sciencebeam_trainer_grobid_tools/structured_document/matching_utils.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/matching_utils.py
@@ -1,6 +1,6 @@
 import logging
 from itertools import islice
-from typing import Callable, List, Tuple
+from typing import Callable, Iterable, List, Tuple
 
 from sciencebeam_utils.utils.collection import (
     iter_flatten
@@ -115,6 +115,13 @@ class JoinedText:
 class SequencesText:
     def __init__(self, sequences: List[SequenceWrapper], sep: str = '\n', pad: str = ''):
         self._joined_text = JoinedText(sequences, sep=sep, pad=pad)
+
+    def iter_sequences_between(self, index_range: Tuple[int, int]) -> Iterable[SequenceWrapper]:
+        seq_and_index_range_iterable = self._joined_text.iter_items_and_index_range_between(
+            index_range
+        )
+        for seq, _ in seq_and_index_range_iterable:
+            yield seq
 
     def iter_tokens_between(self, index_range: Tuple[int, int]):
         start, end = index_range

--- a/sciencebeam_trainer_grobid_tools/structured_document/matching_utils.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/matching_utils.py
@@ -97,6 +97,14 @@ class JoinedText:
         self._items = items
         self._text, self._item_index_ranges = _join_with_index_ranges(items, sep=sep, pad=pad)
 
+    @property
+    def end_index(self):
+        if not self._item_index_ranges:
+            return 0
+        last_index_range = self._item_index_ranges[-1]
+        _, last_index_end = last_index_range
+        return last_index_end
+
     def iter_items_and_index_range_between(self, index_range: Tuple[int, int]):
         start, end = index_range
         for item, (item_start, item_end) in zip(self._items, self._item_index_ranges):
@@ -115,6 +123,10 @@ class JoinedText:
 class SequencesText:
     def __init__(self, sequences: List[SequenceWrapper], sep: str = '\n', pad: str = ''):
         self._joined_text = JoinedText(sequences, sep=sep, pad=pad)
+
+    @property
+    def end_index(self):
+        return self._joined_text.end_index
 
     def iter_sequences_between(self, index_range: Tuple[int, int]) -> Iterable[SequenceWrapper]:
         seq_and_index_range_iterable = self._joined_text.iter_items_and_index_range_between(

--- a/sciencebeam_trainer_grobid_tools/structured_document/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/segmentation_annotator.py
@@ -25,10 +25,15 @@ class FrontTagNames:
     PAGE = 'page'
 
 
+class BackTagNames:
+    REFERENCE = 'reference'
+
+
 class SegmentationTagNames:
     FRONT = 'front'
     PAGE = 'page'
     BODY = 'body'
+    REFERENCE = 'reference'
 
 
 def _get_class_tag_names(c) -> Set[str]:

--- a/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
@@ -65,19 +65,23 @@ class SimpleTagConfig:
             match_prefix_regex: str = None,
             alternative_spellings: Dict[str, List[str]] = None,
             merge_enabled: bool = DEFAULT_MERGE_ENABLED,
-            extend_to_line_enabled: bool = DEFAULT_EXTEND_TO_LINE_ENABLED):
+            extend_to_line_enabled: bool = DEFAULT_EXTEND_TO_LINE_ENABLED,
+            block_name: str = None):
         self.match_prefix_regex = match_prefix_regex
         self.alternative_spellings = alternative_spellings
         self.merge_enabled = merge_enabled
         self.extend_to_line_enabled = extend_to_line_enabled
+        self.block_name = block_name
 
     def __repr__(self):
         return (
             '%s(match_prefix_regex=%s, alternative_spellings=%s,'
-            + ' merge_enabled%s, extend_to_line_enabled=%s)'
+            + ' merge_enabled%s, extend_to_line_enabled=%s,'
+            + ' block_name=%s)'
         ) % (
             type(self).__name__, self.match_prefix_regex, self.alternative_spellings,
-            self.merge_enabled, self.extend_to_line_enabled
+            self.merge_enabled, self.extend_to_line_enabled,
+            self.block_name
         )
 
 
@@ -115,6 +119,9 @@ class SimpleSimpleMatchingConfig:
             self.use_begin_prefix,
             self.tag_config_map
         )
+
+    def get_tag_config(self, tag_name: str) -> SimpleTagConfig:
+        return self.tag_config_map.get(tag_name, DEFAULT_SIMPLE_TAG_CONFIG)
 
 
 def merge_index_ranges(index_ranges: List[Tuple[int, int]]) -> Tuple[int, int]:
@@ -483,21 +490,54 @@ class SimpleMatchingAnnotator(AbstractAnnotator):
             structured_document,
             normalize_fn=normalise_and_remove_junk_str
         )
+        current_pending_sequences = pending_sequences
         target_annotations_grouped_by_tag = groupby(
             self.target_annotations,
             key=lambda target_annotation: target_annotation.name
         )
+        current_block_name = None
         for tag_name, grouped_target_annotations in target_annotations_grouped_by_tag:
+            tag_block_name = self.config.get_tag_config(tag_name).block_name or 'default'
+            LOGGER.debug(
+                'tag_block_name: %s (current_block_name: %s)',
+                tag_block_name, current_block_name
+            )
             grouped_target_annotations = list(grouped_target_annotations)
             LOGGER.debug('grouped_target_annotations: %s', grouped_target_annotations)
             for target_annotation in grouped_target_annotations:
-                text = SequencesText(pending_sequences.get_pending_sequences(
+                text = SequencesText(current_pending_sequences.get_pending_sequences(
                     limit=self.config.lookahead_sequence_count
                 ))
                 index_ranges = list(self.iter_matching_index_ranges(
                     text,
                     [target_annotation]
                 ))
+                if not index_ranges and current_block_name != tag_block_name:
+                    LOGGER.debug(
+                        'block name has changed, scanning whole document (%s)',
+                        tag_block_name
+                    )
+                    text = SequencesText(pending_sequences.get_pending_sequences(
+                        limit=None
+                    ))
+                    index_ranges = list(self.iter_matching_index_ranges(
+                        text,
+                        [target_annotation]
+                    ))
+                    if not index_ranges:
+                        continue
+                    index_range = merge_index_ranges(index_ranges)
+                    block_index_range = (index_range[0], index_range[1] + 1000)
+                    current_pending_sequences = PendingSequences(
+                        list(text.iter_sequences_between(block_index_range))
+                    )
+                    LOGGER.debug(
+                        'set current_pending_sequences to %s (%s), text:\n%s',
+                        block_index_range,
+                        tag_block_name,
+                        SequencesText(current_pending_sequences.get_pending_sequences())
+                    )
+                    current_block_name = tag_block_name
                 if not index_ranges:
                     continue
                 index_range = merge_index_ranges(index_ranges)
@@ -520,6 +560,7 @@ class SimpleTagConfigProps:
     ALTERNATIVE_SPELLINGS = 'alternative-spellings'
     MERGE = 'merge'
     EXTEND_TO_LINE = 'extend-to-line'
+    BLOCK = 'block'
 
 
 def parse_regex(regex_str: str) -> str:
@@ -565,7 +606,10 @@ def get_simple_tag_config(config_map: Dict[str, str], field: str) -> SimpleTagCo
         extend_to_line_enabled=strtobool(config_map.get(
             '%s.%s' % (field, SimpleTagConfigProps.EXTEND_TO_LINE),
             str(DEFAULT_EXTEND_TO_LINE_ENABLED)
-        )) == 1
+        )) == 1,
+        block_name=config_map.get(
+            '%s.%s' % (field, SimpleTagConfigProps.BLOCK)
+        )
     )
 
 

--- a/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
@@ -198,12 +198,15 @@ def select_index_ranges(index_ranges: List[Tuple[int, int]]) -> Tuple[int, int]:
         IndexRangeCluster([index_range])
         for index_range in index_ranges
     ])
-    selected = merged_clusters[0].index_ranges
-    unselected = [
+    sorted_by_length_merged_clusters = sorted(
+        merged_clusters, key=lambda cluster: cluster.length, reverse=True
+    )
+    selected = sorted_by_length_merged_clusters[0].index_ranges
+    unselected = sorted([
         index_range
-        for cluster in merged_clusters[1:]
+        for cluster in sorted_by_length_merged_clusters[1:]
         for index_range in cluster.index_ranges
-    ]
+    ])
     return selected, unselected
 
 

--- a/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/structured_document/simple_matching_annotator.py
@@ -530,7 +530,7 @@ class SimpleMatchingAnnotator(AbstractAnnotator):
                     if not index_ranges:
                         continue
                     index_range = merge_index_ranges(index_ranges)
-                    block_index_range = (index_range[0], index_range[1] + 1000)
+                    block_index_range = (index_range[0], text.end_index)
                     current_pending_sequences = PendingSequences(
                         list(text.iter_sequences_between(block_index_range))
                     )

--- a/tests/annotation/target_annotation_test.py
+++ b/tests/annotation/target_annotation_test.py
@@ -1,8 +1,23 @@
 from lxml.builder import E
 
 from sciencebeam_trainer_grobid_tools.annotation.target_annotation import (
+    contains_raw_text,
     get_raw_text_content
 )
+
+
+class TestContainsRawTextContent:
+    def test_should_return_true_if_element_contains_text(self):
+        assert contains_raw_text(E.node('raw text 1'))
+
+    def test_should_return_false_if_element_contains_child_element_with_text(self):
+        assert not contains_raw_text(E.node(E.child('raw text 1')))
+
+    def test_should_return_true_if_child_element_is_followed_by_text(self):
+        assert contains_raw_text(E.node(E.child('child'), 'tail text'))
+
+    def test_should_return_true_if_child_element_contains_child_element_followed_by_text(self):
+        assert contains_raw_text(E.node(E.child(E.innerChild('child'), 'tail text')))
 
 
 class TestGetRawTextContent:

--- a/tests/structured_document/segmentation_annotator_test.py
+++ b/tests/structured_document/segmentation_annotator_test.py
@@ -6,7 +6,10 @@ from lxml.builder import E
 
 from sciencebeam_trainer_grobid_tools.structured_document.grobid_training_tei import (
     GrobidTrainingTeiStructuredDocument,
-    ContainerNodePaths
+    ContainerNodePaths,
+    add_tag_prefix,
+    B_TAG_PREFIX,
+    I_TAG_PREFIX
 )
 
 from sciencebeam_trainer_grobid_tools.structured_document.segmentation_annotator import (
@@ -34,6 +37,7 @@ DEFAULT_CONFIG = SegmentationConfig({
 TOKEN_1 = 'token1'
 TOKEN_2 = 'token2'
 TOKEN_3 = 'token3'
+TOKEN_4 = 'token4'
 
 
 OTHER_TAG = 'other'
@@ -130,6 +134,30 @@ class TestSegmentationAnnotator:
         assert _get_document_tagged_token_lines(doc) == [
             [
                 (SegmentationTagNames.REFERENCE, TOKEN_1)
+            ]
+        ]
+
+    def test_should_keep_separate_reference(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_1),
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_2)
+            ],
+            [
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_3),
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_4)
+            ]
+        ])
+
+        SegmentationAnnotator(DEFAULT_CONFIG).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_1),
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_2)
+            ],
+            [
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_3),
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_4)
             ]
         ]
 

--- a/tests/structured_document/segmentation_annotator_test.py
+++ b/tests/structured_document/segmentation_annotator_test.py
@@ -14,6 +14,7 @@ from sciencebeam_trainer_grobid_tools.structured_document.segmentation_annotator
     SegmentationConfig,
     SegmentationAnnotator,
     FrontTagNames,
+    BackTagNames,
     SegmentationTagNames
 )
 
@@ -25,7 +26,8 @@ SEGMENTATION_CONTAINER_NODE_PATH = ContainerNodePaths.SEGMENTATION_CONTAINER_NOD
 
 
 DEFAULT_CONFIG = SegmentationConfig({
-    SegmentationTagNames.FRONT: {FrontTagNames.TITLE}
+    SegmentationTagNames.FRONT: {FrontTagNames.TITLE},
+    SegmentationTagNames.REFERENCE: {BackTagNames.REFERENCE}
 })
 
 
@@ -116,6 +118,18 @@ class TestSegmentationAnnotator:
         assert _get_document_tagged_token_lines(doc) == [
             [
                 (SegmentationTagNames.FRONT, TOKEN_1)
+            ]
+        ]
+
+    def test_should_annotate_reference_as_reference(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [(BackTagNames.REFERENCE, TOKEN_1)]
+        ])
+
+        SegmentationAnnotator(DEFAULT_CONFIG).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [
+                (SegmentationTagNames.REFERENCE, TOKEN_1)
             ]
         ]
 

--- a/tests/structured_document/simple_matching_annotator_test.py
+++ b/tests/structured_document/simple_matching_annotator_test.py
@@ -103,6 +103,13 @@ class TestSelectIndexRanges:
         assert selected == [(1, 3)]
         assert unselected == [(103, 105)]
 
+    def test_should_select_second_longer_of_two_apart_index_ranges(self):
+        selected, unselected = select_index_ranges([
+            (1, 3), (103, 109)
+        ])
+        assert selected == [(103, 109)]
+        assert unselected == [(1, 3)]
+
     def test_should_select_two_close_and_unselect_apart_index_ranges(self):
         selected, unselected = select_index_ranges([
             (1, 3), (3, 5), (103, 105)
@@ -547,6 +554,7 @@ class TestSimpleMatchingAnnotator:
         ]
         doc = _document_for_tokens([doc_tokens])
         SimpleMatchingAnnotator(target_annotations).annotate(doc)
+        LOGGER.debug('doc: %s', _get_document_token_tags(doc))
         assert _get_tag_values_of_tokens(matching_tokens) == [TAG1] * len(matching_tokens)
         assert _get_tag_values_of_tokens(pre_tokens) == [None] * len(pre_tokens)
         assert _get_tag_values_of_tokens(post_tokens) == [None] * len(post_tokens)


### PR DESCRIPTION
this makes it possible to properly auto-annotate reference, by:

- allowing references, as a separate block, to scan the whole document once (beyond `--max-lookahead-lines`)
- retain the reference separation in the segmentation annotator
- use the raw reference text where available (improved raw text detection)