### PR TITLE
fixed auto_download_input_file

### DIFF
--- a/sciencebeam_trainer_grobid_tools/utils/io.py
+++ b/sciencebeam_trainer_grobid_tools/utils/io.py
@@ -10,18 +10,23 @@ from apache_beam.io.filesystems import FileSystems
 
 @contextmanager
 def auto_download_input_file(file_url_or_open_fn: Union[str, callable]) -> str:
-    if isinstance(file_url_or_open_fn, Path):
-        file_url_or_open_fn = str(file_url_or_open_fn)
-    if isinstance(file_url_or_open_fn, str) and '://' not in file_url_or_open_fn:
-        yield file_url_or_open_fn
+    file_url = None
+    open_fn = None
+    if isinstance(file_url_or_open_fn, (Path, str)):
+        file_url = str(file_url_or_open_fn)
+    else:
+        open_fn = file_url_or_open_fn
+
+    if file_url and '://' not in file_url:
+        yield file_url
         return
     with TemporaryDirectory(suffix='-input') as temp_dir:
-        if isinstance(file_url_or_open_fn, str):
-            temp_file = os.path.join(temp_dir, os.path.basename(file_url_or_open_fn))
-            FileSystems.copy(file_url_or_open_fn, temp_file)
+        if file_url:
+            temp_file = os.path.join(temp_dir, os.path.basename(file_url))
+            FileSystems.copy([file_url], [temp_file])
         else:
             temp_file = os.path.join(temp_dir, 'temp.file')
-            with file_url_or_open_fn() as source:
+            with open_fn() as source:
                 with open(temp_file, mode='wb') as temp_fp:
                     copyfileobj(source, temp_fp)
         yield temp_file


### PR DESCRIPTION
fixed bug introduced by #135

`FileSystems.copy` expects a list of files rather than individual filenames (currently not invoked by tests as this is meant for copying resources from a bucket)