### PR TITLE
don't encode xml node when cloning

### DIFF
--- a/sciencebeam_trainer_grobid_tools/fix_jats_xml.py
+++ b/sciencebeam_trainer_grobid_tools/fix_jats_xml.py
@@ -92,7 +92,7 @@ ARTICLE_TITLE_PATTERN = r'^(.*?)(\;\s*PMC\d+|\s*,\s*)?$'
 
 
 def clone_node(node: etree.Element) -> etree.Element:
-    return etree.fromstring(etree.tostring(node))
+    return etree.fromstring(etree.tostring(node, encoding='unicode'))
 
 
 def with_element_tail(element: etree.Element, tail: str) -> etree.Element:

--- a/tests/fix_jats_xml_test.py
+++ b/tests/fix_jats_xml_test.py
@@ -80,6 +80,14 @@ def fix_reference(ref: etree.Element) -> etree.Element:
     return fixed_ref
 
 
+class TestCloneNode:
+    def test_should_be_able_to_clone_with_unicode(self):
+        text = '\u002A\u002B\u0026\u00E9\u2122'
+        root = E.root(text)
+        cloned_root = clone_node(root)
+        assert cloned_root.text == text
+
+
 class TestFindDoiValidStartEnd:
     def test_should_find_valid_doi(self):
         text = 'before:  %s' % DOI_1


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/6077

This gets around the following error:

```text
Traceback (most recent call last):
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 708, in process_source_file
    fix_jats_xml_file(source_file, output_file, log_file_enabled=self.log_file_enabled)
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 669, in fix_jats_xml_file
    original_root = clone_node(root)
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 95, in clone_node
    return etree.fromstring(etree.tostring(node))
  File "src/lxml/etree.pyx", line 3237, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1896, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1784, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1141, in lxml.etree._BaseParser._parseDoc
  File "src/lxml/parser.pxi", line 615, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 725, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 654, in lxml.etree._raiseParseError
  File "<string>", line 188
lxml.etree.XMLSyntaxError: PCDATA invalid Char value 2, line 188, column 1070

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/concurrent/futures/process.py", line 175, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 716, in process_source_file_serializable
    raise get_serializable_exception(exc)
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 714, in process_source_file_serializable
    return self.process_source_file(source_file)
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 710, in process_source_file
    raise RuntimeError('failed to process %r due to %r' % (source_file, exc)) from exc
RuntimeError: failed to process '/path/to/859959v1/859959v1.xml.gz' due to XMLSyntaxError('PCDATA invalid Char value 2, line 188, column 1070',)
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 841, in <module>
    main()
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 835, in main
    run(args)
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 827, in run
    FixJatsProcessor(args).run()
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 760, in run
    self.run_local_pipeline(xml_file_list)
  File "/opt/sciencebeam-grobid-trainer-tools/sciencebeam_trainer_grobid_tools/fix_jats_xml.py", line 739, in run_local_pipeline
    future.result()
  File "/usr/local/lib/python3.6/concurrent/futures/_base.py", line 425, in result
    return self.__get_result()
  File "/usr/local/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
RuntimeError: failed to process '/path/to/859959v1/859959v1.xml.gz' due to XMLSyntaxError('PCDATA invalid Char value 2, line 188, column 1070',)
pod "adhoc-fix-biorxiv-xml-train-6000" deleted
pod dev/adhoc-fix-biorxiv-xml-train-6000 terminated (Error)
```

(the unit test isn't actually reproducing the error case)