### PR TITLE
filter xml on the fly

### DIFF
--- a/sciencebeam_trainer_grobid_tools/annotation/annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/annotator.py
@@ -174,7 +174,9 @@ def annotate_structured_document(
 
     if not is_structured_document_passing_checks(structured_document):
         if not failed_target_structured_document_path:
-            LOGGER.warning('document failed checks, skipping')
+            LOGGER.warning(
+                'document failed checks, skipping: %s', source_structured_document_path
+            )
             return
         LOGGER.info('failed checks, saving to: %s', failed_target_structured_document_path)
         save_grobid_training_tei_structured_document(

--- a/sciencebeam_trainer_grobid_tools/annotation/annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/annotator.py
@@ -1,7 +1,7 @@
 import logging
 from collections import Counter
 from functools import partial
-from typing import List, Set
+from typing import Callable, List, Set
 
 from sciencebeam_gym.structured_document import (
     strip_tag_prefix
@@ -16,10 +16,6 @@ from ..structured_document.grobid_training_tei import (
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-def get_logger():
-    return logging.getLogger(__name__)
 
 
 def _iter_all_tokens(structured_document):
@@ -87,7 +83,7 @@ def annotate_structured_document_inplace(
             exclude_fields=exclude_fields
         )
     else:
-        get_logger().debug('not preserving tags')
+        LOGGER.debug('not preserving tags')
         tag_fn = _no_preserve_tag_fn
 
     _map_token_tags(structured_document, tag_fn)
@@ -132,7 +128,7 @@ def _apply_preserved_fields(
         all_preserved_tags.append(full_preserved_tag)
         preserved_tag = strip_tag_prefix(full_preserved_tag)
         if preserved_tag in always_preserve_fields:
-            get_logger().debug('apply preserved field: %s -> %s', token, full_preserved_tag)
+            LOGGER.debug('apply preserved field: %s -> %s', token, full_preserved_tag)
             structured_document.set_tag(token, full_preserved_tag)
             num_tokens += 1
     LOGGER.debug(
@@ -152,8 +148,12 @@ def annotate_structured_document(
         always_preserve_fields: List[str] = None,
         preserve_sub_tags: bool = False,
         no_preserve_sub_fields: Set[str] = None,
+        is_structured_document_passing_checks: Callable[
+            [GrobidTrainingTeiStructuredDocument], bool
+        ] = None,
+        failed_target_structured_document_path: str = None,
         **kwargs):
-    get_logger().info('loading from: %s', source_structured_document_path)
+    LOGGER.info('loading from: %s', source_structured_document_path)
     structured_document = load_grobid_training_tei_structured_document(
         source_structured_document_path,
         **kwargs
@@ -172,7 +172,18 @@ def annotate_structured_document(
         fields=fields
     )
 
-    get_logger().info('saving to: %s', target_structured_document_path)
+    if not is_structured_document_passing_checks(structured_document):
+        if not failed_target_structured_document_path:
+            LOGGER.warning('document failed checks, skipping')
+            return
+        LOGGER.info('failed checks, saving to: %s', failed_target_structured_document_path)
+        save_grobid_training_tei_structured_document(
+            failed_target_structured_document_path,
+            structured_document
+        )
+        return
+
+    LOGGER.info('saving to: %s', target_structured_document_path)
     save_grobid_training_tei_structured_document(
         target_structured_document_path,
         structured_document

--- a/sciencebeam_trainer_grobid_tools/annotation/checks.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/checks.py
@@ -135,8 +135,10 @@ def get_structured_document_entities_by_name(
 def is_structured_document_passing_checks(
         structured_document: GrobidTrainingTeiStructuredDocument,
         require_matching_fields: Set[str],
+        required_fields: Set[str],
         target_annotations: List[TargetAnnotation],
         threshold: float = 0.8) -> bool:
+    require_matching_fields = set(require_matching_fields or set()) | set(required_fields or set())
     if not require_matching_fields:
         return True
     if not target_annotations:
@@ -145,6 +147,12 @@ def is_structured_document_passing_checks(
         target_annotations=target_annotations,
         require_matching_fields=require_matching_fields
     )
+    LOGGER.debug('required_fields: %s', required_fields)
+    if required_fields:
+        missing_required_fields = set(required_fields) - set(required_value_by_name.keys())
+        if missing_required_fields:
+            LOGGER.warning('missing_required_fields: %s', missing_required_fields)
+            return False
     if not required_value_by_name:
         return True
     entities_by_name = get_structured_document_entities_by_name(structured_document)

--- a/sciencebeam_trainer_grobid_tools/annotation/checks.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/checks.py
@@ -1,0 +1,151 @@
+import logging
+from itertools import groupby
+from typing import Iterable, List, Set, Tuple
+
+from sciencebeam_gym.preprocess.annotation.annotator import (
+    AbstractAnnotator,
+    Annotator
+)
+
+from sciencebeam_gym.structured_document import (
+    split_tag_prefix,
+    B_TAG_PREFIX
+)
+
+from sciencebeam_alignment.levenshtein import get_levenshtein_ratio
+
+from ..structured_document.grobid_training_tei import (
+    GrobidTrainingTeiStructuredDocument,
+    TeiText
+)
+
+from .target_annotation import TargetAnnotation
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _iter_all_tokens(
+        structured_document: GrobidTrainingTeiStructuredDocument) -> Iterable[TeiText]:
+    return (
+        token
+        for page in structured_document.get_pages()
+        for line in structured_document.get_lines_of_page(page)
+        for token in structured_document.get_tokens_of_line(line)
+    )
+
+
+def get_token_text(tokens: List[TeiText]) -> str:
+    if not tokens:
+        return ''
+    return ''.join([
+        text
+        for token in tokens[:-1]
+        for text in (token.text, token.whitespace or '')
+    ] + [tokens[-1].text])
+
+
+def get_target_annotation_name(target_annotation: TargetAnnotation) -> str:
+    return target_annotation.name
+
+
+def get_entities_name(entity_pair: Tuple[str, str]) -> str:
+    return entity_pair[0]
+
+
+def iter_structured_document_entities(
+        structured_document: GrobidTrainingTeiStructuredDocument
+        ) -> List[Tuple[str, str]]:
+    pending_tokens = []
+    pending_tag_value = None
+    for token in _iter_all_tokens(structured_document):
+        tag = structured_document.get_tag(token)
+        tag_prefix, tag_value = split_tag_prefix(tag)
+        if pending_tokens:
+            if pending_tag_value != tag_value or tag_prefix == B_TAG_PREFIX:
+                yield pending_tag_value, get_token_text(pending_tokens)
+                pending_tokens = []
+                pending_tag_value = None
+        if not tag_value:
+            continue
+        pending_tag_value = tag_value
+        pending_tokens.append(token)
+    if pending_tokens:
+        yield pending_tag_value, get_token_text(pending_tokens)
+
+
+def is_structured_document_passing_checks(
+        structured_document: GrobidTrainingTeiStructuredDocument,
+        require_matching_fields: Set[str],
+        target_annotations: List[TargetAnnotation],
+        threshold: float = 0.8) -> bool:
+    if not require_matching_fields:
+        return True
+    if not target_annotations:
+        raise RuntimeError('target_annotations required')
+    required_target_annotation_by_name = {
+        name: list(grouped_target_annotations)
+        for name, grouped_target_annotations in groupby(
+            sorted(target_annotations, key=get_target_annotation_name),
+            key=get_target_annotation_name
+        )
+        if name in require_matching_fields
+    }
+    if not required_target_annotation_by_name:
+        return True
+    entities_by_name = {
+        name: [pair[1] for pair in grouped_entities]
+        for name, grouped_entities in groupby(
+            sorted(
+                iter_structured_document_entities(structured_document),
+                key=get_entities_name
+            ),
+            key=get_entities_name
+        )
+    }
+    LOGGER.info('entities_by_name: %s', entities_by_name)
+    for require_matching_field in require_matching_fields:
+        required_target_annotations = required_target_annotation_by_name.get(
+            require_matching_field
+        )
+        if not required_target_annotations:
+            continue
+        if len(required_target_annotations) != 1:
+            raise RuntimeError(
+                'only supporting single value fields, but found: %s' % required_target_annotations
+            )
+        required_value = required_target_annotations[0].value
+        if not isinstance(required_value, str):
+            raise RuntimeError(
+                'only simple str required values supported, but found: %s'
+                % required_target_annotations[0]
+            )
+        actual_entity_values = entities_by_name.get(require_matching_field, [])
+        if not actual_entity_values:
+            LOGGER.warning('required field not in tagged entities: %s', require_matching_field)
+            return False
+        actual_entity_joined_values = ' '.join(actual_entity_values)
+        match_ratio = get_levenshtein_ratio(required_value, actual_entity_joined_values)
+        if match_ratio < threshold:
+            LOGGER.warning(
+                'required field found, but not matching (%s): %r !~ %r',
+                require_matching_field, required_value, actual_entity_joined_values
+            )
+            return False
+    return True
+
+
+def get_target_annotations_from_annotator(
+        annotator: AbstractAnnotator) -> List[TargetAnnotation]:
+    # this is slightly hacky, we just want to get hold of the target annotations
+    # which are hidden in one of the annotator
+    if isinstance(annotator, Annotator):
+        annotators = annotator.annotators
+    else:
+        annotators = [annotator]
+    for _annotator in annotators:
+        try:
+            return _annotator.target_annotations
+        except AttributeError:
+            pass
+    return None

--- a/sciencebeam_trainer_grobid_tools/auto_annotate_header.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_header.py
@@ -58,6 +58,7 @@ class AnnotatePipelineFactory(AbstractAnnotatePipelineFactory):
             container_node_path=HEADER_CONTAINER_NODE_PATH,
             tag_to_tei_path_mapping=HEADER_TAG_TO_TEI_PATH_MAPPING,
             require_matching_fields=opt.require_matching_fields,
+            required_fields=opt.required_fields,
             output_fields=opt.fields
         )
         self.xml_mapping, self.fields = get_xml_mapping_and_fields(

--- a/sciencebeam_trainer_grobid_tools/auto_annotate_header.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_header.py
@@ -17,6 +17,7 @@ from .auto_annotate_utils import (
     process_debug_argument,
     get_xml_mapping_and_fields,
     add_annotation_pipeline_arguments,
+    add_document_checks_arguments,
     process_annotation_pipeline_arguments,
     get_default_annotators,
     AbstractAnnotatePipelineFactory
@@ -80,20 +81,12 @@ class AnnotatePipelineFactory(AbstractAnnotatePipelineFactory):
 
 def add_main_args(parser):
     add_annotation_pipeline_arguments(parser)
+    add_document_checks_arguments(parser)
 
     parser.add_argument(
         '--fields',
         type=comma_separated_str_to_list,
         help='comma separated list of fields to annotate'
-    )
-
-    parser.add_argument(
-        '--require-matching-fields',
-        type=comma_separated_str_to_list,
-        help=(
-            'comma separated list of fields that are required to match (if present).'
-            ' XML files are discarded if one of those fields do not meet the threshold.'
-        )
     )
 
     add_debug_argument(parser)

--- a/sciencebeam_trainer_grobid_tools/auto_annotate_header.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_header.py
@@ -56,6 +56,7 @@ class AnnotatePipelineFactory(AbstractAnnotatePipelineFactory):
             tei_filename_pattern='*.header.tei.xml*',
             container_node_path=HEADER_CONTAINER_NODE_PATH,
             tag_to_tei_path_mapping=HEADER_TAG_TO_TEI_PATH_MAPPING,
+            require_matching_fields=opt.require_matching_fields,
             output_fields=opt.fields
         )
         self.xml_mapping, self.fields = get_xml_mapping_and_fields(
@@ -84,6 +85,15 @@ def add_main_args(parser):
         '--fields',
         type=comma_separated_str_to_list,
         help='comma separated list of fields to annotate'
+    )
+
+    parser.add_argument(
+        '--require-matching-fields',
+        type=comma_separated_str_to_list,
+        help=(
+            'comma separated list of fields that are required to match (if present).'
+            ' XML files are discarded if one of those fields do not meet the threshold.'
+        )
     )
 
     add_debug_argument(parser)

--- a/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import argparse
 import logging
+from typing import List, Set
 
 from sciencebeam_gym.preprocess.annotation.annotator import Annotator
 
@@ -13,6 +14,7 @@ from .auto_annotate_utils import (
     get_xml_mapping_and_fields,
     add_annotation_pipeline_arguments,
     process_annotation_pipeline_arguments,
+    add_document_checks_arguments,
     get_default_annotators,
     get_default_config_path,
     AbstractAnnotatePipelineFactory
@@ -26,6 +28,14 @@ from .annotation.segmentation_annotator import (
     SegmentationConfig,
     parse_segmentation_config
 )
+from .annotation.target_annotation import TargetAnnotation
+from .annotation.checks import (
+    get_required_target_value_by_name,
+    get_structured_document_entities_by_name
+)
+
+from .structured_document.grobid_training_tei import GrobidTrainingTeiStructuredDocument
+from .utils.fuzzy import fuzzy_search
 
 
 LOGGER = logging.getLogger(__name__)
@@ -62,6 +72,57 @@ def _get_annotator(
     return annotator
 
 
+def is_segmentation_structured_document_passing_checks(
+        structured_document: GrobidTrainingTeiStructuredDocument,
+        require_matching_fields: Set[str],
+        target_annotations: List[TargetAnnotation],
+        segmentation_config: SegmentationConfig,
+        threshold: float = 0.8) -> bool:
+    """
+    Segmentation checks are slightly different, because fields like
+    "title" and "abstract" are all put into "front".
+    Therefore we need to map those fields and do a fuzzy search.
+    """
+    if not require_matching_fields:
+        return True
+    if not target_annotations:
+        raise RuntimeError('target_annotations required')
+    required_value_by_name = get_required_target_value_by_name(
+        target_annotations=target_annotations,
+        require_matching_fields=require_matching_fields
+    )
+    if not required_value_by_name:
+        return True
+    entities_by_name = get_structured_document_entities_by_name(structured_document)
+    LOGGER.info('entities_by_name: %s', entities_by_name)
+    expected_entity_by_field_name = {
+        field_name: entity_name
+        for entity_name, field_names in segmentation_config.segmentation_mapping.items()
+        for field_name in field_names
+    }
+    for require_matching_field, required_value in required_value_by_name.items():
+        expected_entity_name = expected_entity_by_field_name[require_matching_field]
+        actual_entity_values = entities_by_name.get(expected_entity_name, [])
+        if not actual_entity_values:
+            LOGGER.warning(
+                'required field not in tagged entities: %s -> %s',
+                require_matching_field, expected_entity_name
+            )
+            return False
+        actual_entity_joined_values = ' '.join(actual_entity_values)
+        match_result = fuzzy_search(
+            actual_entity_joined_values, required_value,
+            threshold=threshold
+        )
+        if not match_result:
+            LOGGER.warning(
+                'required field found, but not matching (%s): %r !~ %r',
+                require_matching_field, required_value, actual_entity_joined_values
+            )
+            return False
+    return True
+
+
 class AnnotatePipelineFactory(AbstractAnnotatePipelineFactory):
     def __init__(self, opt):
         super().__init__(
@@ -69,6 +130,7 @@ class AnnotatePipelineFactory(AbstractAnnotatePipelineFactory):
             tei_filename_pattern='*.segmentation.tei.xml*',
             container_node_path=SEGMENTATION_CONTAINER_NODE_PATH,
             tag_to_tei_path_mapping=SEGMENTATION_TAG_TO_TEI_PATH_MAPPING,
+            require_matching_fields=opt.require_matching_fields,
             output_fields=opt.no_preserve_fields
         )
         self.xml_mapping, self.fields = get_xml_mapping_and_fields(
@@ -88,9 +150,21 @@ class AnnotatePipelineFactory(AbstractAnnotatePipelineFactory):
             preserve_tags=self.preserve_tags
         )
 
+    def is_structured_document_passing_checks(
+            self,
+            structured_document: GrobidTrainingTeiStructuredDocument,
+            target_annotations: List[TargetAnnotation]) -> bool:
+        return is_segmentation_structured_document_passing_checks(
+            structured_document,
+            require_matching_fields=self.require_matching_fields,
+            segmentation_config=self.segmentation_config,
+            target_annotations=target_annotations
+        )
+
 
 def add_main_args(parser):
     add_annotation_pipeline_arguments(parser)
+    add_document_checks_arguments(parser)
 
     parser.add_argument(
         '--fields',

--- a/sciencebeam_trainer_grobid_tools/auto_annotate_utils.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_utils.py
@@ -252,8 +252,16 @@ def add_document_checks_arguments(parser: argparse.ArgumentParser):
         '--require-matching-fields',
         type=comma_separated_str_to_list,
         help=(
-            'comma separated list of fields that are required to match (if present).'
+            'Comma separated list of fields that are required to match (if present).'
             ' XML files are discarded if one of those fields do not meet the threshold.'
+        )
+    )
+    parser.add_argument(
+        '--required-fields',
+        type=comma_separated_str_to_list,
+        help=(
+            'Comma separated list of fields that are required to be present.'
+            ' Where the target value is missing, this would cause the document to fail.'
         )
     )
 
@@ -497,6 +505,7 @@ class AbstractAnnotatePipelineFactory(ABC):
             preserve_sub_tags: bool = False,
             no_preserve_sub_fields: Set[str] = None,
             require_matching_fields: Set[str] = None,
+            required_fields: Set[str] = None,
             namespaces: Dict[str, str] = None):
         self.tei_filename_pattern = tei_filename_pattern
         self.container_node_path = container_node_path
@@ -518,6 +527,7 @@ class AbstractAnnotatePipelineFactory(ABC):
         self.preserve_sub_tags = preserve_sub_tags
         self.no_preserve_sub_fields = no_preserve_sub_fields
         self.require_matching_fields = require_matching_fields
+        self.required_fields = required_fields
         self.output_fields = output_fields
         self.namespaces = namespaces
         self.annotator_config = AnnotatorConfig(
@@ -569,6 +579,7 @@ class AbstractAnnotatePipelineFactory(ABC):
         return is_structured_document_passing_checks(
             structured_document,
             require_matching_fields=self.require_matching_fields,
+            required_fields=self.required_fields,
             target_annotations=target_annotations
         )
 

--- a/tests/annotation/checks_test.py
+++ b/tests/annotation/checks_test.py
@@ -18,6 +18,7 @@ class TestIsStructuredDocumentPassingChecks:
         assert is_structured_document_passing_checks(
             SimpleDocumentBuilder().doc,
             require_matching_fields=[],
+            required_fields=[],
             target_annotations=[
                 TargetAnnotation(name=TAG_1, value=VALUE_1)
             ]
@@ -27,6 +28,7 @@ class TestIsStructuredDocumentPassingChecks:
         assert not is_structured_document_passing_checks(
             SimpleDocumentBuilder().doc,
             require_matching_fields=[TAG_1],
+            required_fields=[],
             target_annotations=[
                 TargetAnnotation(name=TAG_1, value=VALUE_1)
             ]
@@ -36,6 +38,7 @@ class TestIsStructuredDocumentPassingChecks:
         assert is_structured_document_passing_checks(
             SimpleDocumentBuilder().write_entity(TAG_1, VALUE_1).doc,
             require_matching_fields=[TAG_1],
+            required_fields=[],
             target_annotations=[
                 TargetAnnotation(name=TAG_1, value=VALUE_1)
             ]
@@ -45,7 +48,38 @@ class TestIsStructuredDocumentPassingChecks:
         assert not is_structured_document_passing_checks(
             SimpleDocumentBuilder().write_entity(TAG_1, 'other').doc,
             require_matching_fields=[TAG_1],
+            required_fields=[],
             target_annotations=[
                 TargetAnnotation(name=TAG_1, value=VALUE_1)
+            ]
+        )
+
+    def test_should_return_true_if_not_required_fields_is_missing_from_target_values(self):
+        assert is_structured_document_passing_checks(
+            SimpleDocumentBuilder().write_entity(TAG_1, 'other').doc,
+            require_matching_fields=[TAG_1],
+            required_fields=[],
+            target_annotations=[
+                TargetAnnotation(name='other', value=VALUE_1)
+            ]
+        )
+
+    def test_should_return_false_if_required_fields_is_missing_from_target_values(self):
+        assert not is_structured_document_passing_checks(
+            SimpleDocumentBuilder().write_entity(TAG_1, 'other').doc,
+            require_matching_fields=[TAG_1],
+            required_fields=[TAG_1],
+            target_annotations=[
+                TargetAnnotation(name='other', value=VALUE_1)
+            ]
+        )
+
+    def test_should_implictily_select_required_fields(self):
+        assert not is_structured_document_passing_checks(
+            SimpleDocumentBuilder().write_entity(TAG_1, 'other').doc,
+            require_matching_fields=[],
+            required_fields=[TAG_1],
+            target_annotations=[
+                TargetAnnotation(name='other', value=VALUE_1)
             ]
         )

--- a/tests/annotation/checks_test.py
+++ b/tests/annotation/checks_test.py
@@ -1,0 +1,51 @@
+from sciencebeam_trainer_grobid_tools.annotation.target_annotation import (
+    TargetAnnotation
+)
+
+from sciencebeam_trainer_grobid_tools.annotation.checks import (
+    is_structured_document_passing_checks
+)
+
+from ..structured_document.simple_document_builder import SimpleDocumentBuilder
+
+
+TAG_1 = 'tag1'
+VALUE_1 = 'value1'
+
+
+class TestIsStructuredDocumentPassingChecks:
+    def test_should_return_true_without_required_matching_fields(self):
+        assert is_structured_document_passing_checks(
+            SimpleDocumentBuilder().doc,
+            require_matching_fields=[],
+            target_annotations=[
+                TargetAnnotation(name=TAG_1, value=VALUE_1)
+            ]
+        )
+
+    def test_should_return_false_if_required_matching_fields_are_not_tagged(self):
+        assert not is_structured_document_passing_checks(
+            SimpleDocumentBuilder().doc,
+            require_matching_fields=[TAG_1],
+            target_annotations=[
+                TargetAnnotation(name=TAG_1, value=VALUE_1)
+            ]
+        )
+
+    def test_should_return_true_if_required_matching_fields_was_tagged_and_is_matching(self):
+        assert is_structured_document_passing_checks(
+            SimpleDocumentBuilder().write_entity(TAG_1, VALUE_1).doc,
+            require_matching_fields=[TAG_1],
+            target_annotations=[
+                TargetAnnotation(name=TAG_1, value=VALUE_1)
+            ]
+        )
+
+    def test_should_return_false_if_required_matching_fields_was_tagged_but_is_not_matching(self):
+        assert not is_structured_document_passing_checks(
+            SimpleDocumentBuilder().write_entity(TAG_1, 'other').doc,
+            require_matching_fields=[TAG_1],
+            target_annotations=[
+                TargetAnnotation(name=TAG_1, value=VALUE_1)
+            ]
+        )

--- a/tests/auto_annotate_header_test.py
+++ b/tests/auto_annotate_header_test.py
@@ -30,6 +30,11 @@ TEI_FILENAME_REGEX = r'/(.*).header.tei.xml/\1.xml/'
 
 TEXT_1 = 'text 1'
 
+TITLE_1 = 'Chocolate bars for mice'
+ABSTRACT_1 = (
+    'This study explores the nutritious value of chocolate bars for mice.'
+)
+
 
 def get_header_tei_node(
         front_items: List[Union[etree.Element, str]]) -> etree.Element:
@@ -101,23 +106,19 @@ class TestEndToEnd(object):
 
     def test_should_auto_annotate_multiple_fields_using_simple_matcher(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
-        title_text = 'Chocolate bars for mice'
         author_text = 'Mary Maison 1, John Smith 1'
         affiliation_text = '1 University of Science, Smithonia'
-        abstract_text = (
-            'This study explores the nutritious value of chocolate bars for mice.'
-        )
         abstract_prefix = 'Abstract'
         test_helper.tei_raw_file_path.write_bytes(etree.tostring(
             get_header_tei_node([
-                E.note(title_text), E.lb(),
+                E.note(TITLE_1), E.lb(),
                 E.note(author_text), E.lb(),
                 E.note(affiliation_text), E.lb(),
-                E.note(abstract_prefix, E.lb(), abstract_text)
+                E.note(abstract_prefix, E.lb(), ABSTRACT_1)
             ])
         ))
         test_helper.xml_file_path.write_bytes(etree.tostring(get_target_xml_node(
-            title=title_text,
+            title=TITLE_1,
             author_nodes=[
                 E.contrib(E.name(
                     E.surname('Maison'),
@@ -132,7 +133,7 @@ class TestEndToEnd(object):
                     E.country('Smithonia')
                 )
             ],
-            abstract_node=E.abstract(E.p(abstract_text))
+            abstract_node=E.abstract(E.p(ABSTRACT_1))
         )))
         main(dict_to_args({
             **test_helper.main_args_dict,
@@ -141,11 +142,11 @@ class TestEndToEnd(object):
         }), save_main_session=False)
 
         tei_auto_root = test_helper.get_tei_auto_root()
-        assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == title_text
+        assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == TITLE_1
         assert get_xpath_text(tei_auto_root, '//byline/docAuthor') == author_text
         assert get_xpath_text(tei_auto_root, '//byline/affiliation') == affiliation_text
         assert get_xpath_text(tei_auto_root, '//div[@type="abstract"]') == (
-            abstract_prefix + abstract_text
+            abstract_prefix + ABSTRACT_1
         )
 
     def test_should_replace_affiliation_with_author_if_single_tokens(
@@ -190,26 +191,22 @@ class TestEndToEnd(object):
     )
     def test_should_auto_annotate_affiliation_preceding_number_using_simple_matcher(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
-        title_text = 'Chocolate bars for mice'
         author_text = 'Mary Maison 1, John Smith 1'
         affiliation_text_1 = '1'
         affiliation_text_2 = 'University of Science, Smithonia'
         affiliation_text = ' '.join([affiliation_text_1, affiliation_text_2])
-        abstract_text = (
-            'This study explores the nutritious value of chocolate bars for mice.'
-        )
         abstract_prefix = 'Abstract'
         test_helper.tei_raw_file_path.write_bytes(etree.tostring(
             get_header_tei_node([
-                E.note(title_text), E.lb(),
+                E.note(TITLE_1), E.lb(),
                 E.note(author_text), E.lb(),
                 E.note(affiliation_text_1), E.lb(),
                 E.note(affiliation_text_2), E.lb(),
-                E.note(abstract_prefix, E.lb(), abstract_text)
+                E.note(abstract_prefix, E.lb(), ABSTRACT_1)
             ])
         ))
         test_helper.xml_file_path.write_bytes(etree.tostring(get_target_xml_node(
-            title=title_text,
+            title=TITLE_1,
             author_nodes=[
                 E.contrib(E.name(
                     E.surname('Maison'),
@@ -224,7 +221,7 @@ class TestEndToEnd(object):
                     E.country('Smithonia')
                 )
             ],
-            abstract_node=E.abstract(E.p(abstract_text))
+            abstract_node=E.abstract(E.p(ABSTRACT_1))
         )))
         main(dict_to_args({
             **test_helper.main_args_dict,
@@ -233,32 +230,28 @@ class TestEndToEnd(object):
         }), save_main_session=False)
 
         tei_auto_root = test_helper.get_tei_auto_root()
-        assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == title_text
+        assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == TITLE_1
         assert get_xpath_text(tei_auto_root, '//byline/docAuthor') == author_text
         assert get_xpath_text(tei_auto_root, '//byline/affiliation') == affiliation_text
         assert get_xpath_text(tei_auto_root, '//div[@type="abstract"]') == (
-            abstract_prefix + abstract_text
+            abstract_prefix + ABSTRACT_1
         )
 
     def test_should_auto_annotate_alternative_spellings_using_simple_matcher(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
-        title_text = 'Chocolate bars for mice'
         author_text = 'Mary Maison 1, John Smith 1'
         affiliation_text = 'Berkeley, CA 12345, USA'
-        abstract_text = (
-            'This study explores the nutritious value of chocolate bars for mice.'
-        )
         abstract_prefix = 'Abstract'
         test_helper.tei_raw_file_path.write_bytes(etree.tostring(
             get_header_tei_node([
-                E.note(title_text), E.lb(),
+                E.note(TITLE_1), E.lb(),
                 E.note(author_text), E.lb(),
                 E.note(affiliation_text), E.lb(),
-                E.note(abstract_prefix, E.lb(), abstract_text)
+                E.note(abstract_prefix, E.lb(), ABSTRACT_1)
             ])
         ))
         test_helper.xml_file_path.write_bytes(etree.tostring(get_target_xml_node(
-            title=title_text,
+            title=TITLE_1,
             author_nodes=[
                 E.contrib(E.name(
                     E.surname('Maison'),
@@ -273,7 +266,7 @@ class TestEndToEnd(object):
                     E.country('United States')
                 )
             ],
-            abstract_node=E.abstract(E.p(abstract_text))
+            abstract_node=E.abstract(E.p(ABSTRACT_1))
         )))
         main(dict_to_args({
             **test_helper.main_args_dict,
@@ -282,11 +275,11 @@ class TestEndToEnd(object):
         }), save_main_session=False)
 
         tei_auto_root = test_helper.get_tei_auto_root()
-        assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == title_text
+        assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == TITLE_1
         assert get_xpath_text(tei_auto_root, '//byline/docAuthor') == author_text
         assert get_xpath_text(tei_auto_root, '//byline/affiliation') == affiliation_text
         assert get_xpath_text(tei_auto_root, '//div[@type="abstract"]', '|') == (
-            abstract_prefix + abstract_text
+            abstract_prefix + ABSTRACT_1
         )
 
     def test_should_skip_errors(

--- a/tests/auto_annotate_header_test.py
+++ b/tests/auto_annotate_header_test.py
@@ -309,29 +309,38 @@ class TestEndToEnd(object):
         assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == TEXT_1
 
     @pytest.mark.parametrize(
-        'relative_failed_output_path', ['', 'tei-error']
+        'relative_failed_output_path', ['tei-error', '']
     )
     @pytest.mark.parametrize(
-        'actual_abstract,expected_match', [
-            (ABSTRACT_1, True),
-            (NOT_MATCHING_ABSTRACT_1, False)
+        'actual_abstract,expected_abstract,required_fields,expected_match', [
+            (ABSTRACT_1, ABSTRACT_1, '', True),
+            (NOT_MATCHING_ABSTRACT_1, ABSTRACT_1, '', False),
+            ('', ABSTRACT_1, '', False),
+            (ABSTRACT_1, '', '', True),
+            (ABSTRACT_1, '', 'abstract', False)
         ]
     )
     def test_should_filter_out_xml_if_selected_fields_are_not_matching(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper,
             actual_abstract: str,
+            expected_abstract: str,
             expected_match: bool,
+            required_fields: str,
             relative_failed_output_path: str,
             temp_dir: Path):
         test_helper.tei_raw_file_path.write_bytes(etree.tostring(
             get_header_tei_node([
                 E.note(TITLE_1), E.lb(),
-                E.note(ABSTRACT_PREFIX_1, E.lb(), ABSTRACT_1)
+                E.note(ABSTRACT_PREFIX_1, E.lb(), actual_abstract)
             ])
         ))
         test_helper.xml_file_path.write_bytes(etree.tostring(get_target_xml_node(
             title=TITLE_1,
-            abstract_node=E.abstract(E.p(actual_abstract))
+            abstract_node=(
+                E.abstract(E.p(expected_abstract))
+                if expected_abstract
+                else None
+            )
         )))
         failed_output_path = (
             temp_dir / relative_failed_output_path
@@ -342,6 +351,7 @@ class TestEndToEnd(object):
             **test_helper.main_args_dict,
             'fields': ','.join(['title', 'author', 'author_aff', 'abstract']),
             'require-matching-fields': ','.join(['abstract']),
+            'required-fields': required_fields,
             'failed-output-path': failed_output_path,
             'matcher': 'simple'
         }), save_main_session=False)

--- a/tests/auto_annotate_header_test.py
+++ b/tests/auto_annotate_header_test.py
@@ -31,6 +31,7 @@ TEI_FILENAME_REGEX = r'/(.*).header.tei.xml/\1.xml/'
 TEXT_1 = 'text 1'
 
 TITLE_1 = 'Chocolate bars for mice'
+ABSTRACT_PREFIX_1 = 'Abstract'
 ABSTRACT_1 = (
     'This study explores the nutritious value of chocolate bars for mice.'
 )
@@ -108,13 +109,12 @@ class TestEndToEnd(object):
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
         author_text = 'Mary Maison 1, John Smith 1'
         affiliation_text = '1 University of Science, Smithonia'
-        abstract_prefix = 'Abstract'
         test_helper.tei_raw_file_path.write_bytes(etree.tostring(
             get_header_tei_node([
                 E.note(TITLE_1), E.lb(),
                 E.note(author_text), E.lb(),
                 E.note(affiliation_text), E.lb(),
-                E.note(abstract_prefix, E.lb(), ABSTRACT_1)
+                E.note(ABSTRACT_PREFIX_1, E.lb(), ABSTRACT_1)
             ])
         ))
         test_helper.xml_file_path.write_bytes(etree.tostring(get_target_xml_node(
@@ -146,7 +146,7 @@ class TestEndToEnd(object):
         assert get_xpath_text(tei_auto_root, '//byline/docAuthor') == author_text
         assert get_xpath_text(tei_auto_root, '//byline/affiliation') == affiliation_text
         assert get_xpath_text(tei_auto_root, '//div[@type="abstract"]') == (
-            abstract_prefix + ABSTRACT_1
+            ABSTRACT_PREFIX_1 + ABSTRACT_1
         )
 
     def test_should_replace_affiliation_with_author_if_single_tokens(
@@ -195,14 +195,13 @@ class TestEndToEnd(object):
         affiliation_text_1 = '1'
         affiliation_text_2 = 'University of Science, Smithonia'
         affiliation_text = ' '.join([affiliation_text_1, affiliation_text_2])
-        abstract_prefix = 'Abstract'
         test_helper.tei_raw_file_path.write_bytes(etree.tostring(
             get_header_tei_node([
                 E.note(TITLE_1), E.lb(),
                 E.note(author_text), E.lb(),
                 E.note(affiliation_text_1), E.lb(),
                 E.note(affiliation_text_2), E.lb(),
-                E.note(abstract_prefix, E.lb(), ABSTRACT_1)
+                E.note(ABSTRACT_PREFIX_1, E.lb(), ABSTRACT_1)
             ])
         ))
         test_helper.xml_file_path.write_bytes(etree.tostring(get_target_xml_node(
@@ -234,20 +233,19 @@ class TestEndToEnd(object):
         assert get_xpath_text(tei_auto_root, '//byline/docAuthor') == author_text
         assert get_xpath_text(tei_auto_root, '//byline/affiliation') == affiliation_text
         assert get_xpath_text(tei_auto_root, '//div[@type="abstract"]') == (
-            abstract_prefix + ABSTRACT_1
+            ABSTRACT_PREFIX_1 + ABSTRACT_1
         )
 
     def test_should_auto_annotate_alternative_spellings_using_simple_matcher(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
         author_text = 'Mary Maison 1, John Smith 1'
         affiliation_text = 'Berkeley, CA 12345, USA'
-        abstract_prefix = 'Abstract'
         test_helper.tei_raw_file_path.write_bytes(etree.tostring(
             get_header_tei_node([
                 E.note(TITLE_1), E.lb(),
                 E.note(author_text), E.lb(),
                 E.note(affiliation_text), E.lb(),
-                E.note(abstract_prefix, E.lb(), ABSTRACT_1)
+                E.note(ABSTRACT_PREFIX_1, E.lb(), ABSTRACT_1)
             ])
         ))
         test_helper.xml_file_path.write_bytes(etree.tostring(get_target_xml_node(
@@ -279,7 +277,7 @@ class TestEndToEnd(object):
         assert get_xpath_text(tei_auto_root, '//byline/docAuthor') == author_text
         assert get_xpath_text(tei_auto_root, '//byline/affiliation') == affiliation_text
         assert get_xpath_text(tei_auto_root, '//div[@type="abstract"]', '|') == (
-            abstract_prefix + ABSTRACT_1
+            ABSTRACT_PREFIX_1 + ABSTRACT_1
         )
 
     def test_should_skip_errors(

--- a/tests/auto_annotate_header_test.py
+++ b/tests/auto_annotate_header_test.py
@@ -309,7 +309,7 @@ class TestEndToEnd(object):
         assert get_xpath_text(tei_auto_root, '//docTitle/titlePart') == TEXT_1
 
     @pytest.mark.parametrize(
-        'relative_failed_output_path', ['tei-error']
+        'relative_failed_output_path', ['', 'tei-error']
     )
     @pytest.mark.parametrize(
         'actual_abstract,expected_match', [

--- a/tests/auto_annotate_segmentation_test.py
+++ b/tests/auto_annotate_segmentation_test.py
@@ -41,6 +41,15 @@ TOKEN_3 = 'token3'
 LABEL_1 = '1'
 REFERENCE_TEXT_1 = 'reference A'
 
+TITLE_1 = 'Chocolate bars for mice'
+ABSTRACT_PREFIX_1 = 'Abstract'
+ABSTRACT_1 = (
+    'This study explores the nutritious value of chocolate bars for mice.'
+)
+NOT_MATCHING_ABSTRACT_1 = (
+    'Something different.'
+)
+
 
 def get_segmentation_tei_node(
         text_items: List[Union[etree.Element, str]]) -> etree.Element:
@@ -272,3 +281,48 @@ class TestEndToEnd(object):
         tei_auto_root = test_helper.get_tei_auto_root()
         assert get_xpath_text(tei_auto_root, '//text/page') == ''
         assert get_xpath_text(tei_auto_root, '//text/body') == TOKEN_1
+
+    @pytest.mark.parametrize(
+        'relative_failed_output_path', ['', 'tei-error']
+    )
+    @pytest.mark.parametrize(
+        'actual_abstract,expected_match', [
+            (ABSTRACT_1, True),
+            (NOT_MATCHING_ABSTRACT_1, False)
+        ]
+    )
+    def test_should_filter_out_xml_if_selected_fields_are_not_matching(
+            self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper,
+            actual_abstract: str,
+            expected_match: bool,
+            relative_failed_output_path: str,
+            temp_dir: Path):
+        test_helper.tei_raw_file_path.write_bytes(etree.tostring(
+            get_segmentation_tei_node([
+                E.note(TITLE_1), E.lb(),
+                E.note(ABSTRACT_PREFIX_1, E.lb(), ABSTRACT_1)
+            ])
+        ))
+        test_helper.xml_file_path.write_bytes(etree.tostring(get_target_xml_node(
+            title=TITLE_1,
+            abstract_node=E.abstract(E.p(actual_abstract))
+        )))
+        failed_output_path = (
+            temp_dir / relative_failed_output_path
+            if relative_failed_output_path
+            else ''
+        )
+        main(dict_to_args({
+            **test_helper.main_args_dict,
+            'fields': ','.join(['title', 'author', 'author_aff', 'abstract']),
+            'require-matching-fields': ','.join(['abstract']),
+            'failed-output-path': failed_output_path,
+            'matcher': 'simple'
+        }), save_main_session=False)
+
+        if not expected_match:
+            assert not test_helper.tei_auto_file_path.exists()
+            if failed_output_path:
+                assert (failed_output_path / test_helper.tei_auto_file_path.name).exists()
+        else:
+            assert test_helper.tei_auto_file_path.exists()

--- a/tests/structured_document/simple_document_builder.py
+++ b/tests/structured_document/simple_document_builder.py
@@ -1,0 +1,50 @@
+import re
+from typing import List
+
+from sciencebeam_gym.structured_document import (
+    SimpleStructuredDocument,
+    SimplePage,
+    SimpleLine,
+    SimpleToken,
+    B_TAG_PREFIX,
+    I_TAG_PREFIX,
+    add_tag_prefix
+)
+
+
+def get_token_texts_for_text(text: str) -> List[str]:
+    return [s for s in re.split(r'(\W)', text) if s.strip()]
+
+
+def get_entity_tokens(tag: str, value: str) -> List[SimpleToken]:
+    return [
+        SimpleToken(token_text, tag=add_tag_prefix(
+            tag,
+            prefix=B_TAG_PREFIX if index == 0 else I_TAG_PREFIX
+        ))
+        for index, token_text in enumerate(get_token_texts_for_text(value))
+    ]
+
+
+class SimpleDocumentBuilder:
+    def __init__(self):
+        self.doc = SimpleStructuredDocument(lines=[])
+
+    @property
+    def current_page(self) -> SimplePage:
+        return self.doc._pages[-1]  # pylint: disable=protected-access
+
+    def get_or_create_current_line(self) -> SimpleLine:
+        lines = self.current_page.lines
+        if not lines:
+            lines.append(SimpleLine([]))
+        return lines[-1]
+
+    def write_tokens(self, tokens: List[SimpleToken]):
+        line = self.get_or_create_current_line()
+        line.tokens.extend(tokens)
+        return self
+
+    def write_entity(self, tag: str, value: str):
+        self.write_tokens(get_entity_tokens(tag, value))
+        return self


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/7

added the following parameters to the `segmentation` and `header` auto annotators:

|argument | description |
| ------------ | ---------------|
| `--require-matching-fields` | Can be set to `abstract` to skip an XML file, if the abstract does not match (assuming it is one of the target values) |
| `--required-fields` | In addition to the above, this will also skip the XML if there isn't a target value. e.g. it would skip all documents without an abstract |
| `--failed-output-path` | If specified, rather than just skipping the XML, it will save the XML files failing the checks to the specified path |