### PR TITLE
annotate top level body paragraphs

### DIFF
--- a/config/xml-mapping.conf
+++ b/config/xml-mapping.conf
@@ -72,7 +72,9 @@ section_title =
 section_title.children = ./title
 section_title.children.concat = [[{"xpath": "./label"}, {"value": " "}, {"xpath": "./title"}]]
 
-section_paragraph = (//sec | //ack)/p
+section_paragraph =
+  (//sec | //ack)/p
+  ./body/p
 section_paragraph.sub.section_paragraph-xref-bib = .//xref[@ref-type="bibr"]
 section_paragraph.sub.section_paragraph-xref-figure = .//xref[@ref-type="fig"]
 section_paragraph.sub.section_paragraph-xref-table = .//xref[@ref-type="table"]

--- a/tests/auto_annotate_fulltext_test.py
+++ b/tests/auto_annotate_fulltext_test.py
@@ -136,6 +136,27 @@ class TestEndToEnd(object):
             SECTION_LABEL_1 + ' ' + SECTION_TITLE_1
         ]
 
+    def test_should_auto_annotate_single_top_level_body_paragraphs(
+            self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
+        # e.g. `153445v1` contains paragraphs as direct children of the body
+        target_body_content_nodes = [E.p(TEXT_1)]
+        tei_text = get_nodes_text(target_body_content_nodes)
+        test_helper.tei_raw_file_path.write_bytes(etree.tostring(
+            get_training_tei_node([tei_text])
+        ))
+        test_helper.xml_file_path.write_bytes(etree.tostring(
+            get_target_xml_node(body_nodes=target_body_content_nodes)
+        ))
+        main(dict_to_args({
+            **test_helper.main_args_dict,
+            'fields': ','.join([
+                'section_paragraph'
+            ])
+        }), save_main_session=False)
+
+        tei_auto_root = test_helper.get_tei_auto_root()
+        assert get_xpath_text_list(tei_auto_root, '//p') == [TEXT_1]
+
     def test_should_auto_annotate_single_back_section_title_and_paragraph(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
         target_back_content_nodes = [


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/44

Some documents, e.g. `153445v1`, contain paragraphs (`p`) as immediate children of the `body`, rather than being within a section (`sec`).