### PR TITLE
annotate lists within paragraphs

### DIFF
--- a/config/xml-mapping.conf
+++ b/config/xml-mapping.conf
@@ -75,6 +75,7 @@ section_title.children.concat = [[{"xpath": "./label"}, {"value": " "}, {"xpath"
 section_paragraph =
   (//sec | //ack)/p
   ./body/p
+section_paragraph.ignore = .//list
 section_paragraph.sub.section_paragraph-xref-bib = .//xref[@ref-type="bibr"]
 section_paragraph.sub.section_paragraph-xref-figure = .//xref[@ref-type="fig"]
 section_paragraph.sub.section_paragraph-xref-table = .//xref[@ref-type="table"]
@@ -88,6 +89,7 @@ boxed_text_title.children = ./label | ./caption
 boxed_text_title.children.concat = [[{"xpath": "./label"}, {"value": " "}, {"xpath": "./caption"}]]
 
 boxed_text_paragraph = //boxed-text//p
+boxed_text_paragraph.ignore = .//list
 boxed_text_paragraph.sub.boxed_text_paragraph-xref-bib = .//xref[@ref-type="bibr"]
 boxed_text_paragraph.sub.boxed_text_paragraph-xref-figure = .//xref[@ref-type="fig"]
 boxed_text_paragraph.sub.boxed_text_paragraph-xref-table = .//xref[@ref-type="table"]


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/44

this is pulling lists out of paragraphs in order to annotate them separately.
(ideally they would be annotated within a paragraph, but it shouldn't make a big difference)