### PR TITLE
enable fulltext extend to line

### DIFF
--- a/sciencebeam_trainer_grobid_tools/auto_annotate_fulltext.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_fulltext.py
@@ -136,7 +136,7 @@ def _get_annotator(
     simple_annotator_config = annotator_config.get_simple_annotator_config(
         xml_mapping=xml_mapping,
         preserve_sub_annotations=True,
-        extend_to_line_enabled=False
+        extend_to_line_enabled=True
     )
     annotators = [
         SimpleMatchingAnnotator(

--- a/tests/auto_annotate_fulltext_test.py
+++ b/tests/auto_annotate_fulltext_test.py
@@ -108,6 +108,57 @@ class TestEndToEnd(object):
         assert get_xpath_text_list(tei_auto_root, '//head') == [SECTION_TITLE_1]
         assert get_xpath_text_list(tei_auto_root, '//p') == [TEXT_1]
 
+    def test_should_extend_to_line_by_default(
+            self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
+        target_body_content_nodes = [
+            E.sec(
+                'x ',
+                E.title(SECTION_TITLE_1),
+            )
+        ]
+        tei_text = get_nodes_text(target_body_content_nodes)
+        test_helper.tei_raw_file_path.write_bytes(etree.tostring(
+            get_training_tei_node([tei_text])
+        ))
+        test_helper.xml_file_path.write_bytes(etree.tostring(
+            get_target_xml_node(body_nodes=target_body_content_nodes)
+        ))
+        main(dict_to_args({
+            **test_helper.main_args_dict,
+            'fields': ','.join([
+                'section_title'
+            ])
+        }), save_main_session=False)
+
+        tei_auto_root = test_helper.get_tei_auto_root()
+        assert get_xpath_text_list(tei_auto_root, '//head') == ['x ' + SECTION_TITLE_1]
+
+    def test_should_not_extend_to_line_if_disabled(
+            self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
+        target_body_content_nodes = [
+            E.sec(
+                'x ',
+                E.title(SECTION_TITLE_1),
+            )
+        ]
+        tei_text = get_nodes_text(target_body_content_nodes)
+        test_helper.tei_raw_file_path.write_bytes(etree.tostring(
+            get_training_tei_node([tei_text])
+        ))
+        test_helper.xml_file_path.write_bytes(etree.tostring(
+            get_target_xml_node(body_nodes=target_body_content_nodes)
+        ))
+        main(dict_to_args({
+            **test_helper.main_args_dict,
+            'no-extend-to-line': True,
+            'fields': ','.join([
+                'section_title'
+            ])
+        }), save_main_session=False)
+
+        tei_auto_root = test_helper.get_tei_auto_root()
+        assert get_xpath_text_list(tei_auto_root, '//head') == [SECTION_TITLE_1]
+
     def test_should_auto_annotate_single_section_title_with_label(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
         target_body_content_nodes = [

--- a/tests/auto_annotate_test_utils.py
+++ b/tests/auto_annotate_test_utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import List, Union
 
 from lxml import etree
-from lxml.builder import E
+from lxml.builder import E, ElementMaker
 
 from sciencebeam_utils.utils.xml import get_text_content
 
@@ -57,6 +57,20 @@ def _add_all(parent: etree.Element, children: List[Union[str, etree.Element]]):
         else:
             parent.append(child)
             previous_child = child
+
+
+def get_tei_nodes_for_text(
+        text: str,
+        element_maker: ElementMaker = None) -> List[Union[str, etree.Element]]:
+    if element_maker is None:
+        element_maker = E
+    result = []
+    for index, line in enumerate(text.splitlines()):
+        if index:
+            result.append(element_maker.lb)
+            result.append('\n')
+        result.append(line)
+    return result
 
 
 def get_target_xml_node(


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/44

this is to include some tokens that may not be in the target XML. e.g. bullets for list items.