### PR TITLE
annotate keywords

### DIFF
--- a/sciencebeam_trainer_grobid_tools/auto_annotate_fulltext.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_fulltext.py
@@ -68,6 +68,7 @@ XREF_REL_TEI_PATH_MAPPING = {
 FULLTEXT_TAG_TO_TEI_PATH_MAPPING = {
     DEFAULT_TAG_KEY: 'other',
     'note_other': 'note[@type="other"]',
+    'keywords': 'other[@type="keywords"]',
     'section_title': 'head',
     'section_paragraph': 'p',
     **{
@@ -94,6 +95,7 @@ FULLTEXT_TAG_TO_TEI_PATH_MAPPING = {
 
 
 ALL_FIELDS = [
+    'keywords',
     'section_title',
     'section_paragraph',
     'boxed_text_title',

--- a/tests/auto_annotate_fulltext_test.py
+++ b/tests/auto_annotate_fulltext_test.py
@@ -1018,6 +1018,43 @@ class TestEndToEnd(object):
             SECTION_TITLE_1
         ]
 
+    def test_should_auto_annotate_keywords(
+            self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
+        target_keywords_nodes = [
+            E('kwd-group', *[
+                E.title('Keywords'),
+                ': ',
+                E.kwd('Keyword 1'),
+                ', ',
+                E.kwd('Keyword 2'),
+                ', ',
+                E.kwd('Keyword 3')
+            ])
+        ]
+        target_article_meta_nodes = [
+            'Heading\n',
+            *target_keywords_nodes,
+            '\nMore text'
+        ]
+        tei_text = get_nodes_text(target_article_meta_nodes)
+        test_helper.tei_raw_file_path.write_bytes(etree.tostring(
+            get_training_tei_node(get_tei_nodes_for_text(tei_text))
+        ))
+        test_helper.xml_file_path.write_bytes(etree.tostring(
+            get_target_xml_node(article_meta_nodes=target_article_meta_nodes)
+        ))
+        main(dict_to_args({
+            **test_helper.main_args_dict,
+            'fields': ','.join([
+                'keywords'
+            ])
+        }), save_main_session=False)
+
+        tei_auto_root = test_helper.get_tei_auto_root()
+        assert get_xpath_text_list(tei_auto_root, '//other[@type="keywords"]') == [
+            get_nodes_text(target_keywords_nodes)
+        ]
+
     def test_should_convert_note_other_to_other(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
         target_body_content_nodes = []

--- a/tests/auto_annotate_test_utils.py
+++ b/tests/auto_annotate_test_utils.py
@@ -53,7 +53,10 @@ def _add_all(parent: etree.Element, children: List[Union[str, etree.Element]]):
     previous_child = None
     for child in children:
         if isinstance(child, str):
-            previous_child.tail = (previous_child.tail or '') + child
+            if previous_child is not None:
+                previous_child.tail = (previous_child.tail or '') + child
+            else:
+                parent.text = (parent.text or '') + child
         else:
             parent.append(child)
             previous_child = child
@@ -78,6 +81,7 @@ def get_target_xml_node(
         author_nodes: List[etree.Element] = None,
         affiliation_nodes: List[etree.Element] = None,
         abstract_node: etree.Element = None,
+        article_meta_nodes: List[etree.Element] = None,
         body_nodes: List[etree.Element] = None,
         back_nodes: List[etree.Element] = None,
         reference_nodes: List[etree.Element] = None) -> etree.Element:
@@ -90,6 +94,7 @@ def get_target_xml_node(
         article_meta_node.append(E('title-group', E('article-title', title)))
     _add_all(contrib_group, author_nodes)
     _add_all(contrib_group, affiliation_nodes)
+    _add_all(article_meta_node, article_meta_nodes)
     _add_all(body_node, body_nodes)
     _add_all(back_node, back_nodes)
     if abstract_node is not None:


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/44

If the section title is also a keyword, then the keyword would get annotated as section title instead.
Annotating the keywords avoids that.