### PR TITLE
pull out figures from paragraphs

### DIFF
--- a/config/xml-mapping.conf
+++ b/config/xml-mapping.conf
@@ -76,7 +76,7 @@ section_title.children.concat = [[{"xpath": "./label"}, {"value": " "}, {"xpath"
 section_paragraph =
   (//sec | //ack)/p
   ./body/p
-section_paragraph.ignore = .//list
+section_paragraph.ignore = .//list|fig|table-wrap
 section_paragraph.max_chunks = 2
 section_paragraph.sub.section_paragraph-xref-bib = .//xref[@ref-type="bibr"]
 section_paragraph.sub.section_paragraph-xref-figure = .//xref[@ref-type="fig"]
@@ -91,7 +91,7 @@ boxed_text_title.children = ./label | ./caption
 boxed_text_title.children.concat = [[{"xpath": "./label"}, {"value": " "}, {"xpath": "./caption"}]]
 
 boxed_text_paragraph = //boxed-text//p
-boxed_text_paragraph.ignore = .//list
+boxed_text_paragraph.ignore = .//list|fig|table-wrap
 boxed_text_paragraph.max_chunks = 2
 boxed_text_paragraph.sub.boxed_text_paragraph-xref-bib = .//xref[@ref-type="bibr"]
 boxed_text_paragraph.sub.boxed_text_paragraph-xref-figure = .//xref[@ref-type="fig"]


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/44

For example `341453v1` contains figures embedded in paragraphs. That affects the annotation of the paragraph (and probably the figure).