### PR TITLE
detect page headers

### DIFF
--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -193,6 +193,17 @@ class SegmentationLineList:
         return line.segmentation_tag if line else None
 
 
+def apply_preserved_page_numbers(
+    segmentation_lines: SegmentationLineList
+):
+    for line in segmentation_lines.iter_untagged():
+        tags = _get_line_token_tags_or_preserved_tags(
+            line.structured_document, line.line
+        )
+        if SegmentationTagNames.PAGE in tags:
+            line.set_segmentation_tag(SegmentationTagNames.PAGE)
+
+
 def find_and_tag_page_headers(
     segmentation_lines: SegmentationLineList
 ):
@@ -303,6 +314,8 @@ class SegmentationAnnotator(AbstractAnnotator):
 
             line.segmentation_tag = segmentation_tag or majority_tag_name
 
+        if self.preserve_tags:
+            apply_preserved_page_numbers(segmentation_lines)
         find_and_tag_page_headers(segmentation_lines)
         merge_front_lines(
             segmentation_lines=segmentation_lines,

--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -31,6 +31,10 @@ class FrontTagNames:
     ABSTRACT = 'abstract'
 
 
+class BodyTagNames:
+    SECTION_TITLE = 'section_title'
+
+
 class BackTagNames:
     REFERENCE = 'reference'
 
@@ -214,7 +218,10 @@ def merge_front_lines(
     condidate_lines = []
     previous_segmentation_tag: Optional[str] = SegmentationTagNames.FRONT
     total_merged_lines = 0
+    ignored_segmentation_tags = {SegmentationTagNames.HEADNOTE, SegmentationTagNames.PAGE}
     for line in segmentation_lines:
+        if line.segmentation_tag in ignored_segmentation_tags:
+            continue
         if line.segmentation_tag:
             previous_segmentation_tag = line.segmentation_tag
         if line.segmentation_tag == SegmentationTagNames.FRONT:

--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -242,9 +242,25 @@ def find_missing_page_numbers(
         if is_valid_page_number_candidate(line.text)
     ]
     LOGGER.debug('page_number_candidates: %s', page_number_candidates)
-    for page_number_candidate in page_number_candidates:
-        LOGGER.debug('setting page number candidate: %s', page_number_candidate)
-        page_number_candidate.line.set_segmentation_tag(SegmentationTagNames.PAGE)
+    min_line_number = 0
+    min_page_number = 1
+    for existing_page_number_candidate in existing_page_number_candidates:
+        max_line_number = existing_page_number_candidate.line.line_index
+        max_page_number = existing_page_number_candidate.page_number - 1
+        for page_number_candidate in page_number_candidates:
+            if page_number_candidate.line.line_index < min_line_number:
+                continue
+            if page_number_candidate.line.line_index > max_line_number:
+                continue
+            if page_number_candidate.page_number < min_page_number:
+                continue
+            if page_number_candidate.page_number > max_page_number:
+                continue
+            LOGGER.debug('setting page number candidate: %s', page_number_candidate)
+            page_number_candidate.line.set_segmentation_tag(SegmentationTagNames.PAGE)
+            min_page_number += 1
+        min_line_number = max_line_number
+        min_page_number = max_page_number + 1
 
 
 def is_valid_page_header_candidate(

--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -63,19 +63,10 @@ DEFAULT_FRONT_MAX_START_LINE_INDEX = 30
 DEFAULT_PAGE_HEADER_MAX_FIRST_LINE_INDEX = 50
 
 
-class SegmentationConfig:
-    def __init__(
-        self,
-        segmentation_mapping: Dict[str, Set[str]],
-        front_max_start_line_index: int = DEFAULT_FRONT_MAX_START_LINE_INDEX,
-        page_header_max_first_line_index: int = DEFAULT_PAGE_HEADER_MAX_FIRST_LINE_INDEX
-    ):
-        self.segmentation_mapping = segmentation_mapping
-        self.front_max_start_line_index = front_max_start_line_index
-        self.page_header_max_first_line_index = page_header_max_first_line_index
-
-    def __repr__(self):
-        return '%s(%s)' % (type(self), self.__dict__)
+class SegmentationConfig(NamedTuple):
+    segmentation_mapping: Dict[str, Set[str]]
+    front_max_start_line_index: int = DEFAULT_FRONT_MAX_START_LINE_INDEX
+    page_header_max_first_line_index: int = DEFAULT_PAGE_HEADER_MAX_FIRST_LINE_INDEX
 
 
 def parse_segmentation_config(filename: str) -> SegmentationConfig:

--- a/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
@@ -51,6 +51,7 @@ SEGMENTATION_TAG_TO_TEI_PATH_MAPPING = {
     'headnote': 'div[@type="headnote"]',
     'acknowledgment': 'div[@type="acknowledgment"]',
     'annex': 'div[@type="annex"]',
+    'page': 'page',
     'line_no': 'note[@type="line_no"]',
     'reference': 'listBibl'
 }

--- a/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
@@ -48,7 +48,7 @@ SEGMENTATION_CONTAINER_NODE_PATH = ContainerNodePaths.SEGMENTATION_CONTAINER_NOD
 SEGMENTATION_TAG_TO_TEI_PATH_MAPPING = {
     DEFAULT_TAG_KEY: 'body',
     'body': 'body',
-    'headnote': 'div[@type="headnote"]',
+    'headnote': 'note[@place="headnote"]',
     'acknowledgment': 'div[@type="acknowledgment"]',
     'annex': 'div[@type="annex"]',
     'page': 'page',

--- a/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
@@ -47,6 +47,8 @@ SEGMENTATION_CONTAINER_NODE_PATH = ContainerNodePaths.SEGMENTATION_CONTAINER_NOD
 
 SEGMENTATION_TAG_TO_TEI_PATH_MAPPING = {
     DEFAULT_TAG_KEY: 'body',
+    'body': 'body',
+    'headnote': 'div[@type="headnote"]',
     'acknowledgment': 'div[@type="acknowledgment"]',
     'annex': 'div[@type="annex"]',
     'line_no': 'note[@type="line_no"]',

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -435,3 +435,20 @@ class TestSegmentationAnnotator:
             [(SegmentationTagNames.PAGE, '1')],
             [(SegmentationTagNames.BODY, TOKEN_2)]
         ]
+
+    def test_should_find_missing_page_numbers_annotations(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [(None, '1')],
+            [(FrontTagNames.TITLE, TOKEN_1)],
+            [(SegmentationTagNames.PAGE, '2')],
+            [(BodyTagNames.SECTION_TITLE, TOKEN_2)],
+            [(SegmentationTagNames.PAGE, '3')]
+        ])
+        SegmentationAnnotator(DEFAULT_CONFIG, preserve_tags=True).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [(SegmentationTagNames.PAGE, '1')],
+            [(SegmentationTagNames.FRONT, TOKEN_1)],
+            [(SegmentationTagNames.PAGE, '2')],
+            [(SegmentationTagNames.BODY, TOKEN_2)],
+            [(SegmentationTagNames.PAGE, '3')]
+        ]

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -452,3 +452,20 @@ class TestSegmentationAnnotator:
             [(SegmentationTagNames.BODY, TOKEN_2)],
             [(SegmentationTagNames.PAGE, '3')]
         ]
+
+    def test_should_not_annotate_out_of_order_page_number(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [(None, '2')],
+            [(FrontTagNames.TITLE, TOKEN_1)],
+            [(SegmentationTagNames.PAGE, '2')],
+            [(BodyTagNames.SECTION_TITLE, TOKEN_2)],
+            [(SegmentationTagNames.PAGE, '3')]
+        ])
+        SegmentationAnnotator(DEFAULT_CONFIG, preserve_tags=True).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [(SegmentationTagNames.FRONT, '2')],
+            [(SegmentationTagNames.FRONT, TOKEN_1)],
+            [(SegmentationTagNames.PAGE, '2')],
+            [(SegmentationTagNames.BODY, TOKEN_2)],
+            [(SegmentationTagNames.PAGE, '3')]
+        ]

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -2,8 +2,6 @@ import logging
 from pathlib import Path
 from typing import List, Tuple
 
-import pytest
-
 from lxml.builder import E
 
 from sciencebeam_trainer_grobid_tools.structured_document.grobid_training_tei import (
@@ -32,7 +30,7 @@ SEGMENTATION_CONTAINER_NODE_PATH = ContainerNodePaths.SEGMENTATION_CONTAINER_NOD
 
 
 DEFAULT_CONFIG = SegmentationConfig({
-    SegmentationTagNames.FRONT: {FrontTagNames.TITLE},
+    SegmentationTagNames.FRONT: {FrontTagNames.TITLE, FrontTagNames.ABSTRACT},
     SegmentationTagNames.REFERENCE: {BackTagNames.REFERENCE}
 })
 
@@ -332,7 +330,6 @@ class TestSegmentationAnnotator:
             [(None, TOKEN_3)]
         ]
 
-    @pytest.mark.skip()
     def test_should_annotate_page_header(self):
         doc = _simple_document_with_tagged_token_lines(lines=[
             [(None, TOKEN_1)],
@@ -343,10 +340,8 @@ class TestSegmentationAnnotator:
 
         SegmentationAnnotator(DEFAULT_CONFIG).annotate(doc)
         assert _get_document_tagged_token_lines(doc) == [
-            [
-                (SegmentationTagNames.HEADNOTE, TOKEN_1),
-                (SegmentationTagNames.FRONT, TOKEN_2),
-                (SegmentationTagNames.HEADNOTE, TOKEN_1),
-                (SegmentationTagNames.FRONT, TOKEN_3)
-            ]
+            [(SegmentationTagNames.HEADNOTE, TOKEN_1)],
+            [(SegmentationTagNames.FRONT, TOKEN_2)],
+            [(SegmentationTagNames.HEADNOTE, TOKEN_1)],
+            [(SegmentationTagNames.FRONT, TOKEN_3)]
         ]

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -2,6 +2,8 @@ import logging
 from pathlib import Path
 from typing import List, Tuple
 
+import pytest
+
 from lxml.builder import E
 
 from sciencebeam_trainer_grobid_tools.structured_document.grobid_training_tei import (
@@ -16,6 +18,7 @@ from sciencebeam_trainer_grobid_tools.annotation.segmentation_annotator import (
     parse_segmentation_config,
     SegmentationConfig,
     SegmentationAnnotator,
+    PageTagNames,
     FrontTagNames,
     BackTagNames,
     SegmentationTagNames
@@ -290,7 +293,7 @@ class TestSegmentationAnnotator:
     def test_should_not_annotate_untagged_page_no_lines_between_first_and_last_header(self):
         doc = _simple_document_with_tagged_token_lines(lines=[
             [(FrontTagNames.TITLE, TOKEN_1)],
-            [(FrontTagNames.PAGE, TOKEN_2)],
+            [(PageTagNames.PAGE, TOKEN_2)],
             [(FrontTagNames.TITLE, TOKEN_3)]
         ])
 
@@ -327,4 +330,23 @@ class TestSegmentationAnnotator:
             [(None, TOKEN_1)],
             [(None, TOKEN_2)],
             [(None, TOKEN_3)]
+        ]
+
+    @pytest.mark.skip()
+    def test_should_annotate_page_header(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [(None, TOKEN_1)],
+            [(FrontTagNames.TITLE, TOKEN_2)],
+            [(None, TOKEN_1)],
+            [(FrontTagNames.ABSTRACT, TOKEN_3)],
+        ])
+
+        SegmentationAnnotator(DEFAULT_CONFIG).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [
+                (SegmentationTagNames.HEADNOTE, TOKEN_1),
+                (SegmentationTagNames.FRONT, TOKEN_2),
+                (SegmentationTagNames.HEADNOTE, TOKEN_1),
+                (SegmentationTagNames.FRONT, TOKEN_3)
+            ]
         ]

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -440,9 +440,9 @@ class TestSegmentationAnnotator:
         doc = _simple_document_with_tagged_token_lines(lines=[
             [(None, '1')],
             [(FrontTagNames.TITLE, TOKEN_1)],
-            [(SegmentationTagNames.PAGE, '2')],
+            [(PageTagNames.PAGE, '2')],
             [(BodyTagNames.SECTION_TITLE, TOKEN_2)],
-            [(SegmentationTagNames.PAGE, '3')]
+            [(PageTagNames.PAGE, '3')]
         ])
         SegmentationAnnotator(DEFAULT_CONFIG, preserve_tags=True).annotate(doc)
         assert _get_document_tagged_token_lines(doc) == [
@@ -457,9 +457,9 @@ class TestSegmentationAnnotator:
         doc = _simple_document_with_tagged_token_lines(lines=[
             [(None, '2')],
             [(FrontTagNames.TITLE, TOKEN_1)],
-            [(SegmentationTagNames.PAGE, '2')],
+            [(PageTagNames.PAGE, '2')],
             [(BodyTagNames.SECTION_TITLE, TOKEN_2)],
-            [(SegmentationTagNames.PAGE, '3')]
+            [(PageTagNames.PAGE, '3')]
         ])
         SegmentationAnnotator(DEFAULT_CONFIG, preserve_tags=True).annotate(doc)
         assert _get_document_tagged_token_lines(doc) == [

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -369,3 +369,22 @@ class TestSegmentationAnnotator:
             [(SegmentationTagNames.BODY, TOKEN_3)],
             [(SegmentationTagNames.BODY, TOKEN_4)]
         ]
+
+    def test_should_not_annotate_preserved_page_numbers_as_headnote(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [(None, '1')],
+            [(FrontTagNames.TITLE, TOKEN_1)],
+            [(None, '1')],
+            [(BodyTagNames.SECTION_TITLE, TOKEN_2)],
+        ])
+        all_tokens = list(doc.iter_all_tokens())
+        doc._set_preserved_tag(all_tokens[0], PageTagNames.PAGE)  # pylint: disable=protected-access
+        doc._set_preserved_tag(all_tokens[2], PageTagNames.PAGE)  # pylint: disable=protected-access
+
+        SegmentationAnnotator(DEFAULT_CONFIG, preserve_tags=True).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [(SegmentationTagNames.PAGE, '1')],
+            [(SegmentationTagNames.FRONT, TOKEN_1)],
+            [(SegmentationTagNames.PAGE, '1')],
+            [(SegmentationTagNames.BODY, TOKEN_2)]
+        ]

--- a/tests/auto_annotate_segmentation_test.py
+++ b/tests/auto_annotate_segmentation_test.py
@@ -710,17 +710,13 @@ class TestEndToEnd(object):
             'Page header',
             'Page header'
         ]
-        # assert get_xpath_text_list(tei_auto_root, '//text/front') == [
-        #     TITLE_1
-        # ]
-        # assert get_xpath_text_list(tei_auto_root, '//text/body') == [
-        #     TEXT_1
-        # ]
-        # assert get_xpath_text_list(tei_auto_root, '//text/div[@type="headnote"]') == [
-        #     'Before title',
-        #     '\n'.join(['After title', 'Before paragraph']),
-        #     'After paragraph'
-        # ]
+        assert get_xpath_text_list(tei_auto_root, '//text/front') == [
+            '\n'.join(['Before title', TITLE_1])
+        ]
+        assert get_xpath_text_list(tei_auto_root, '//text/body') == [
+            'After title',
+            '\n'.join(['Before paragraph', TEXT_1, 'After paragraph'])
+        ]
 
     @pytest.mark.parametrize(
         'relative_failed_output_path', ['tei-error', '']

--- a/tests/auto_annotate_segmentation_test.py
+++ b/tests/auto_annotate_segmentation_test.py
@@ -670,7 +670,7 @@ class TestEndToEnd(object):
             '123',
             '123'
         ]
-        assert get_xpath_text_list(tei_auto_root, '//text/div[@type="headnote"]') == [
+        assert get_xpath_text_list(tei_auto_root, '//text/note[@place="headnote"]') == [
             'Page header',
             'Page header'
         ]
@@ -706,7 +706,7 @@ class TestEndToEnd(object):
         }), save_main_session=False)
 
         tei_auto_root = test_helper.get_tei_auto_root()
-        assert get_xpath_text_list(tei_auto_root, '//text/div[@type="headnote"]') == [
+        assert get_xpath_text_list(tei_auto_root, '//text/note[@place="headnote"]') == [
             'Page header',
             'Page header'
         ]

--- a/tests/auto_annotate_test_utils.py
+++ b/tests/auto_annotate_test_utils.py
@@ -69,7 +69,8 @@ def _add_all(parent: etree.Element, children: List[Union[str, etree.Element]]):
 
 def get_tei_nodes_for_text(
         text: str,
-        element_maker: ElementMaker = None) -> List[Union[str, etree.Element]]:
+        element_maker: ElementMaker = None,
+        trailing_line_feed: bool = False) -> List[Union[str, etree.Element]]:
     if element_maker is None:
         element_maker = E
     result = []
@@ -78,7 +79,19 @@ def get_tei_nodes_for_text(
             result.append(element_maker.lb)
             result.append('\n')
         result.append(line)
+    if trailing_line_feed:
+        result.append(element_maker.lb)
+        result.append('\n')
     return result
+
+
+def get_tei_nodes_for_lines(lines: List[str], *args, **kwargs) -> List[Union[str, etree.Element]]:
+    return get_tei_nodes_for_text(
+        '\n'.join(lines),
+        *args,
+        trailing_line_feed=True,
+        **kwargs
+    )
 
 
 def get_target_xml_node(


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/92

This attempts to detect page headers (`headnote`) among the text that isn't annotated via the target XML.