### PR TITLE
fixed abstract cut off in segmentation annotator

### DIFF
--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -59,7 +59,7 @@ def _get_class_tag_names(c) -> Set[str]:
 FRONT_TAG_NAMES = _get_class_tag_names(FrontTagNames)
 
 
-DEFAULT_FRONT_MAX_START_LINE_INDEX = 30
+DEFAULT_FRONT_MAX_START_LINE_INDEX = 0
 DEFAULT_PAGE_HEADER_MAX_FIRST_LINE_INDEX = 50
 
 

--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -197,6 +197,31 @@ class SegmentationLineList:
         return line.segmentation_tag if line else None
 
 
+def clear_front_tags_for_front_blocks_starting_after_threshold(
+    segmentation_lines: SegmentationLineList,
+    max_block_start_line_index: int
+):
+    if not max_block_start_line_index:
+        LOGGER.debug('no max_block_start_line_index set')
+        return
+    block_segmentation_tag = None
+    block_start_line_index = 0
+    for line in segmentation_lines:
+        if line.segmentation_tag != block_segmentation_tag:
+            block_segmentation_tag = line.segmentation_tag
+            block_start_line_index = line.line_index
+        if (
+            block_segmentation_tag == SegmentationTagNames.FRONT
+            and block_start_line_index > max_block_start_line_index
+        ):
+            LOGGER.debug(
+                'ignore front tag beyond line index threshold (%d > %d), line: %r',
+                block_start_line_index, max_block_start_line_index, line
+            )
+            line.clear_line_token_tags()
+            continue
+
+
 def apply_preserved_page_numbers(
     segmentation_lines: SegmentationLineList
 ):
@@ -373,7 +398,6 @@ class SegmentationAnnotator(AbstractAnnotator):
             for line_index, line in enumerate(_iter_all_lines(structured_document))
         ])
         for line in segmentation_lines.lines:
-            line_index = line.line_index
             full_line_token_tags = line.get_line_token_tags()
             line_token_tags = _to_tag_values(full_line_token_tags)
             line_tag_counts = Counter(line_token_tags)
@@ -386,18 +410,6 @@ class SegmentationAnnotator(AbstractAnnotator):
                 line_tag_counts, majority_tag_name, segmentation_tag
             )
 
-            if (
-                segmentation_tag == SegmentationTagNames.FRONT
-                and self.config.front_max_start_line_index
-                and line_index > self.config.front_max_start_line_index
-            ):
-                LOGGER.debug(
-                    'ignore front tag beyond line index threshold (%d > %d)',
-                    line_index, self.config.front_max_start_line_index
-                )
-                segmentation_tag = None
-                line.clear_line_token_tags()
-
             if segmentation_tag and segmentation_tag == majority_tag_name:
                 LOGGER.debug(
                     'keep line tokens for %s',
@@ -409,6 +421,11 @@ class SegmentationAnnotator(AbstractAnnotator):
                 line.clear_line_token_tags()
 
             line.segmentation_tag = segmentation_tag or majority_tag_name
+
+        clear_front_tags_for_front_blocks_starting_after_threshold(
+            segmentation_lines,
+            max_block_start_line_index=self.config.front_max_start_line_index
+        )
 
         if self.preserve_tags:
             apply_preserved_page_numbers(segmentation_lines)

--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -219,7 +219,6 @@ def clear_front_tags_for_front_blocks_starting_after_threshold(
                 block_start_line_index, max_block_start_line_index, line
             )
             line.clear_line_token_tags()
-            continue
 
 
 def apply_preserved_page_numbers(

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -381,6 +381,24 @@ class TestSegmentationAnnotator:
             [(None, TOKEN_3)]
         ]
 
+    def test_should_keep_front_if_line_index_of_front_started_before_threshold(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [(FrontTagNames.TITLE, TOKEN_1)],
+            [(FrontTagNames.TITLE, TOKEN_2)],
+            [(FrontTagNames.TITLE, TOKEN_3)]
+        ])
+
+        config = SegmentationConfig(
+            DEFAULT_CONFIG.segmentation_mapping,
+            front_max_start_line_index=1
+        )
+        SegmentationAnnotator(config, preserve_tags=True).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [(SegmentationTagNames.FRONT, TOKEN_1)],
+            [(SegmentationTagNames.FRONT, TOKEN_2)],
+            [(SegmentationTagNames.FRONT, TOKEN_3)]
+        ]
+
     def test_should_annotate_page_header(self):
         doc = _simple_document_with_tagged_token_lines(lines=[
             [(None, t) for t in LONG_PAGE_HEADER_TEXT_1.split(' ')],


### PR DESCRIPTION
resolves https://github.com/elifesciences/sciencebeam-issues/issues/107

It turns out that the bug was introduced when I refactored the segmentation post annotator.
There is a check to prevent "front" blocks to start at a high line number where they seem "unlikely" (with a default of line index 30).
But after the refractory it was just looking at the line index rather than the line index when the block started. Therefore it would cut the abstract where it had gone beyond the threshold. I have fixed that.

While at the same time, the very same check should probably not be used anymore. Now that it is looking at all of the sections, the segmentation parser seems to be more resilient. And sometimes some front tags (such as affiliation) do actually appear near the end of the document. Therefore I have deactivated it by default.