### PR TITLE
merge references in segmentation model

### DIFF
--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -67,6 +67,7 @@ class SegmentationConfig(NamedTuple):
     segmentation_mapping: Dict[str, Set[str]]
     front_max_start_line_index: int = DEFAULT_FRONT_MAX_START_LINE_INDEX
     page_header_max_first_line_index: int = DEFAULT_PAGE_HEADER_MAX_FIRST_LINE_INDEX
+    no_merge_references: bool = False
 
 
 def parse_segmentation_config(filename: str) -> SegmentationConfig:
@@ -414,6 +415,8 @@ class SegmentationAnnotator(AbstractAnnotator):
                     'keep line tokens for %s',
                     segmentation_tag
                 )
+                if not self.config.no_merge_references:
+                    line.set_segmentation_tag(segmentation_tag)
             elif segmentation_tag:
                 line.set_segmentation_tag(segmentation_tag)
             elif majority_tag_name is None:

--- a/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
+++ b/sciencebeam_trainer_grobid_tools/auto_annotate_segmentation.py
@@ -178,6 +178,10 @@ class AnnotatePipelineFactory(AbstractAnnotatePipelineFactory):
             xml_mapping_overrides=opt.xml_mapping_overrides
         )
         self.segmentation_config = parse_segmentation_config(opt.segmentation_config)
+        if opt.no_merge_references:
+            self.segmentation_config = self.segmentation_config._replace(
+                no_merge_references=True
+            )
 
     def get_annotator(self, source_url: str):
         target_xml_path = self.get_target_xml_for_source_file(source_url)
@@ -211,6 +215,12 @@ def add_main_args(parser):
         '--no-preserve-fields',
         type=comma_separated_str_to_list,
         help='comma separated list of output fields that should not be preserved'
+    )
+
+    parser.add_argument(
+        '--no-merge-references',
+        action='store_true',
+        help='disable merging of references'
     )
 
     parser.add_argument(

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -189,7 +189,7 @@ class TestSegmentationAnnotator:
             ]
         ]
 
-    def test_should_keep_separate_reference(self):
+    def test_should_merge_separate_reference_if_enabled(self):
         doc = _simple_document_with_tagged_token_lines(lines=[
             [
                 (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_1),
@@ -201,7 +201,35 @@ class TestSegmentationAnnotator:
             ]
         ])
 
-        SegmentationAnnotator(DEFAULT_CONFIG).annotate(doc)
+        SegmentationAnnotator(
+            DEFAULT_CONFIG._replace(no_merge_references=False)
+        ).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [
+                (BackTagNames.REFERENCE, TOKEN_1),
+                (BackTagNames.REFERENCE, TOKEN_2)
+            ],
+            [
+                (BackTagNames.REFERENCE, TOKEN_3),
+                (BackTagNames.REFERENCE, TOKEN_4)
+            ]
+        ]
+
+    def test_should_keep_separate_reference_if_disabled(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_1),
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_2)
+            ],
+            [
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_3),
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_4)
+            ]
+        ])
+
+        SegmentationAnnotator(
+            DEFAULT_CONFIG._replace(no_merge_references=True)
+        ).annotate(doc)
         assert _get_document_tagged_token_lines(doc) == [
             [
                 (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_1),


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/117

This merges `listBibl` as per upstream GROBID training data.
(The old behaviour can be turned back on by adding `--no-merge-references`)