### PR TITLE
fixed ack sub section

### DIFF
--- a/config/xml-mapping.conf
+++ b/config/xml-mapping.conf
@@ -86,13 +86,13 @@ section_paragraph.sub.section_paragraph-xref-box = .//xref[@ref-type="boxed-text
 
 # for the segmentation model we need separate body and back section, but no granular sub-fields
 body_section_title = body//sec/title
-back_section_title = back//sec/title
+back_section_title = back//sec[not(ancestor::ack)]/title
 
 body_section_paragraph = body//p
-back_section_paragraph = back//p[not(ancestor::ack)]
+back_section_paragraph = back//sec[not(ancestor::ack)]/p[not(ancestor::ack)] | back//p[not(ancestor::sec) and not(ancestor::ack)]
 
-acknowledgment_section_title = //ack/title
-acknowledgment_section_paragraph = //ack/p
+acknowledgment_section_title = //ack//title
+acknowledgment_section_paragraph = //ack//p
 
 boxed_text_title =
   //boxed-text

--- a/tests/auto_annotate_segmentation_test.py
+++ b/tests/auto_annotate_segmentation_test.py
@@ -293,6 +293,37 @@ class TestEndToEnd(object):
         tei_auto_root = test_helper.get_tei_auto_root()
         assert get_xpath_text_list(tei_auto_root, '//div[@type="acknowledgment"]') == [tei_text]
 
+    def test_should_auto_annotate_acknowledgment_sub_section_as_acknowledgment(
+            self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
+        target_back_content_nodes = [
+            E.ack(E.sec(
+                E.title(SECTION_TITLE_2),
+                '\n',
+                E.p(TEXT_2)
+            ))
+        ]
+        tei_text = get_nodes_text(target_back_content_nodes)
+        test_helper.tei_raw_file_path.write_bytes(etree.tostring(
+            get_training_tei_node(get_tei_nodes_for_text(tei_text))
+        ))
+        test_helper.xml_file_path.write_bytes(etree.tostring(
+            get_target_xml_node(back_nodes=target_back_content_nodes)
+        ))
+        main(dict_to_args({
+            **test_helper.main_args_dict,
+            'fields': ','.join([
+                'body_section_title',
+                'body_section_paragraph',
+                'back_section_title',
+                'back_section_paragraph',
+                'acknowledgment_section_title',
+                'acknowledgment_section_paragraph'
+            ])
+        }), save_main_session=False)
+
+        tei_auto_root = test_helper.get_tei_auto_root()
+        assert get_xpath_text_list(tei_auto_root, '//div[@type="acknowledgment"]') == [tei_text]
+
     def test_should_auto_annotate_appendix_section_as_annex(
             self, test_helper: SingleFileAutoAnnotateEndToEndTestHelper):
         target_back_content_nodes = [


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/117

Fixed `ack` sub section (with `sec` within `ack`) were not annotated correctly by the segmentation model.
That was due to the xml mapping config.