### PR TITLE
segmentation merge untagged between references

### DIFF
--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -348,7 +348,8 @@ def find_and_tag_page_headers(
 def merge_lines(
     segmentation_lines: SegmentationLineList,
     preserve_tags: bool,
-    enabled_tags: Set[str]
+    enabled_tags: Set[str],
+    enabled_remaining_tags: Set[str]
 ):
     condidate_lines = []
     previous_segmentation_tag: Optional[str] = SegmentationTagNames.FRONT
@@ -382,6 +383,14 @@ def merge_lines(
             continue
         if previous_segmentation_tag in enabled_tags:
             condidate_lines.append(line)
+    if condidate_lines and previous_segmentation_tag in enabled_remaining_tags:
+        LOGGER.debug(
+            'tagging remaining as %r, merging with previous lines: %s',
+            previous_segmentation_tag, condidate_lines
+        )
+        total_merged_line_counts[previous_segmentation_tag] += len(condidate_lines)
+        for condidate_line in condidate_lines:
+            condidate_line.set_segmentation_tag(previous_segmentation_tag)
     LOGGER.debug('merged lines, %s', total_merged_line_counts)
 
 
@@ -447,7 +456,8 @@ class SegmentationAnnotator(AbstractAnnotator):
         merge_lines(
             segmentation_lines=segmentation_lines,
             preserve_tags=self.preserve_tags,
-            enabled_tags=enabled_tags
+            enabled_tags=enabled_tags,
+            enabled_remaining_tags={SegmentationTagNames.ANNEX}
         )
 
         if not self.preserve_tags:

--- a/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
+++ b/sciencebeam_trainer_grobid_tools/annotation/segmentation_annotator.py
@@ -38,6 +38,7 @@ class BodyTagNames:
 
 class BackTagNames:
     REFERENCE = 'reference'
+    APPENDIX = 'appendix'
 
 
 class SegmentationTagNames:
@@ -46,6 +47,7 @@ class SegmentationTagNames:
     HEADNOTE = 'headnote'
     BODY = 'body'
     REFERENCE = 'reference'
+    ANNEX = 'annex'
 
 
 def _get_class_tag_names(c) -> Set[str]:
@@ -439,7 +441,7 @@ class SegmentationAnnotator(AbstractAnnotator):
             segmentation_lines,
             max_first_line_index=self.config.page_header_max_first_line_index
         )
-        enabled_tags = {SegmentationTagNames.FRONT}
+        enabled_tags = {SegmentationTagNames.FRONT, SegmentationTagNames.ANNEX}
         if not self.config.no_merge_references:
             enabled_tags.add(SegmentationTagNames.REFERENCE)
         merge_lines(

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -42,6 +42,8 @@ TOKEN_1 = 'token1'
 TOKEN_2 = 'token2'
 TOKEN_3 = 'token3'
 TOKEN_4 = 'token4'
+TOKEN_5 = 'token5'
+TOKEN_6 = 'token6'
 
 PAGE_HEADER_TOKEN_1 = 'Page_Header_1'
 
@@ -238,6 +240,40 @@ class TestSegmentationAnnotator:
             [
                 (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_3),
                 (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_4)
+            ]
+        ]
+
+    def test_should_merge_and_fill_gap_between_reference_if_enabled(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_1),
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_2)
+            ],
+            [
+                (None, TOKEN_3),
+                (None, TOKEN_4)
+            ],
+            [
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_5),
+                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_6)
+            ]
+        ])
+
+        SegmentationAnnotator(
+            DEFAULT_CONFIG._replace(no_merge_references=False)
+        ).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [
+                (BackTagNames.REFERENCE, TOKEN_1),
+                (BackTagNames.REFERENCE, TOKEN_2)
+            ],
+            [
+                (BackTagNames.REFERENCE, TOKEN_3),
+                (BackTagNames.REFERENCE, TOKEN_4)
+            ],
+            [
+                (BackTagNames.REFERENCE, TOKEN_5),
+                (BackTagNames.REFERENCE, TOKEN_6)
             ]
         ]
 

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -278,7 +278,7 @@ class TestSegmentationAnnotator:
             ]
         ]
 
-    def test_should_merge_and_fill_gap_between_back_tags_if_enabled(self):
+    def test_should_merge_and_fill_gap_between_back_tags(self):
         doc = _simple_document_with_tagged_token_lines(lines=[
             [
                 (add_tag_prefix(BackTagNames.APPENDIX, prefix=B_TAG_PREFIX), TOKEN_1),
@@ -309,6 +309,32 @@ class TestSegmentationAnnotator:
             [
                 (SegmentationTagNames.ANNEX, TOKEN_5),
                 (SegmentationTagNames.ANNEX, TOKEN_6)
+            ]
+        ]
+
+    def test_should_merge_and_fill_remaining_untagged_with_annex(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [
+                (add_tag_prefix(BackTagNames.APPENDIX, prefix=B_TAG_PREFIX), TOKEN_1),
+                (add_tag_prefix(BackTagNames.APPENDIX, prefix=I_TAG_PREFIX), TOKEN_2)
+            ],
+            [
+                (None, TOKEN_3),
+                (None, TOKEN_4)
+            ]
+        ])
+
+        SegmentationAnnotator(
+            DEFAULT_CONFIG._replace(no_merge_references=False)
+        ).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [
+                (SegmentationTagNames.ANNEX, TOKEN_1),
+                (SegmentationTagNames.ANNEX, TOKEN_2)
+            ],
+            [
+                (SegmentationTagNames.ANNEX, TOKEN_3),
+                (SegmentationTagNames.ANNEX, TOKEN_4)
             ]
         ]
 

--- a/tests/annotation/segmentation_annotator_test.py
+++ b/tests/annotation/segmentation_annotator_test.py
@@ -34,7 +34,8 @@ SEGMENTATION_CONTAINER_NODE_PATH = ContainerNodePaths.SEGMENTATION_CONTAINER_NOD
 DEFAULT_CONFIG = SegmentationConfig({
     SegmentationTagNames.FRONT: {FrontTagNames.TITLE, FrontTagNames.ABSTRACT},
     SegmentationTagNames.BODY: {BodyTagNames.SECTION_TITLE},
-    SegmentationTagNames.REFERENCE: {BackTagNames.REFERENCE}
+    SegmentationTagNames.REFERENCE: {BackTagNames.REFERENCE},
+    SegmentationTagNames.ANNEX: {BackTagNames.APPENDIX}
 })
 
 
@@ -208,12 +209,12 @@ class TestSegmentationAnnotator:
         ).annotate(doc)
         assert _get_document_tagged_token_lines(doc) == [
             [
-                (BackTagNames.REFERENCE, TOKEN_1),
-                (BackTagNames.REFERENCE, TOKEN_2)
+                (SegmentationTagNames.REFERENCE, TOKEN_1),
+                (SegmentationTagNames.REFERENCE, TOKEN_2)
             ],
             [
-                (BackTagNames.REFERENCE, TOKEN_3),
-                (BackTagNames.REFERENCE, TOKEN_4)
+                (SegmentationTagNames.REFERENCE, TOKEN_3),
+                (SegmentationTagNames.REFERENCE, TOKEN_4)
             ]
         ]
 
@@ -234,12 +235,12 @@ class TestSegmentationAnnotator:
         ).annotate(doc)
         assert _get_document_tagged_token_lines(doc) == [
             [
-                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_1),
-                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_2)
+                (add_tag_prefix(SegmentationTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_1),
+                (add_tag_prefix(SegmentationTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_2)
             ],
             [
-                (add_tag_prefix(BackTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_3),
-                (add_tag_prefix(BackTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_4)
+                (add_tag_prefix(SegmentationTagNames.REFERENCE, prefix=B_TAG_PREFIX), TOKEN_3),
+                (add_tag_prefix(SegmentationTagNames.REFERENCE, prefix=I_TAG_PREFIX), TOKEN_4)
             ]
         ]
 
@@ -264,16 +265,50 @@ class TestSegmentationAnnotator:
         ).annotate(doc)
         assert _get_document_tagged_token_lines(doc) == [
             [
-                (BackTagNames.REFERENCE, TOKEN_1),
-                (BackTagNames.REFERENCE, TOKEN_2)
+                (SegmentationTagNames.REFERENCE, TOKEN_1),
+                (SegmentationTagNames.REFERENCE, TOKEN_2)
             ],
             [
-                (BackTagNames.REFERENCE, TOKEN_3),
-                (BackTagNames.REFERENCE, TOKEN_4)
+                (SegmentationTagNames.REFERENCE, TOKEN_3),
+                (SegmentationTagNames.REFERENCE, TOKEN_4)
             ],
             [
-                (BackTagNames.REFERENCE, TOKEN_5),
-                (BackTagNames.REFERENCE, TOKEN_6)
+                (SegmentationTagNames.REFERENCE, TOKEN_5),
+                (SegmentationTagNames.REFERENCE, TOKEN_6)
+            ]
+        ]
+
+    def test_should_merge_and_fill_gap_between_back_tags_if_enabled(self):
+        doc = _simple_document_with_tagged_token_lines(lines=[
+            [
+                (add_tag_prefix(BackTagNames.APPENDIX, prefix=B_TAG_PREFIX), TOKEN_1),
+                (add_tag_prefix(BackTagNames.APPENDIX, prefix=I_TAG_PREFIX), TOKEN_2)
+            ],
+            [
+                (None, TOKEN_3),
+                (None, TOKEN_4)
+            ],
+            [
+                (add_tag_prefix(BackTagNames.APPENDIX, prefix=B_TAG_PREFIX), TOKEN_5),
+                (add_tag_prefix(BackTagNames.APPENDIX, prefix=I_TAG_PREFIX), TOKEN_6)
+            ]
+        ])
+
+        SegmentationAnnotator(
+            DEFAULT_CONFIG._replace(no_merge_references=False)
+        ).annotate(doc)
+        assert _get_document_tagged_token_lines(doc) == [
+            [
+                (SegmentationTagNames.ANNEX, TOKEN_1),
+                (SegmentationTagNames.ANNEX, TOKEN_2)
+            ],
+            [
+                (SegmentationTagNames.ANNEX, TOKEN_3),
+                (SegmentationTagNames.ANNEX, TOKEN_4)
+            ],
+            [
+                (SegmentationTagNames.ANNEX, TOKEN_5),
+                (SegmentationTagNames.ANNEX, TOKEN_6)
             ]
         ]
 


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/117 and https://github.com/elifesciences/sciencebeam-issues/issues/95

Some reference are not tagged because they cross page boundaries and mismatches are caused by the page header. Due to the potential short length, reference are currently not split. This change will assume that untagged lines between references (after considering the page header), are also references. That should mean that only references at the very beginning or end could still be affected.